### PR TITLE
Add loader tests for JSON parsing and error handling

### DIFF
--- a/client/src/test/characterLoader.test.ts
+++ b/client/src/test/characterLoader.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadNPCData, loadPCData } from '../lib/characterLoader';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('characterLoader', () => {
+  it('loadNPCData parses response', async () => {
+    const npc = {
+      id: 'npc1',
+      name: 'Goblin',
+      icon: 'g',
+      color: 'green',
+      position: 'right' as const,
+      stats: {
+        health: 5,
+        maxHealth: 5,
+        armor: 0,
+        maxArmor: 0,
+        willToFight: 3,
+        maxWill: 3,
+        awareness: 1,
+        maxAwareness: 2
+      }
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([npc])
+    } as any);
+
+    const result = await loadNPCData();
+    expect(global.fetch).toHaveBeenCalledWith('/data/characters/npcs.json');
+    expect(result).toEqual([
+      {
+        ...npc,
+        description: `NPC character: ${npc.name}`,
+        actions: ['attack', 'defend']
+      }
+    ]);
+  });
+
+  it('loadNPCData returns empty array on error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false } as any);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await loadNPCData();
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('loadPCData parses response', async () => {
+    const pc = {
+      id: 'pc',
+      name: 'Hero',
+      icon: 'h',
+      color: 'blue',
+      stats: { hidden: false, actionPoints: 1, maxActionPoints: 1 },
+      abilities: []
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(pc)
+    } as any);
+    const result = await loadPCData();
+    expect(global.fetch).toHaveBeenCalledWith('/data/characters/pc.json');
+    expect(result).toEqual(pc);
+  });
+
+  it('loadPCData returns null on error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('fail'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await loadPCData();
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/client/src/test/environmentLoader.test.ts
+++ b/client/src/test/environmentLoader.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadEnvironmentalEffects } from '../lib/environmentLoader';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('environmentLoader', () => {
+  it('loadEnvironmentalEffects parses response', async () => {
+    const data = {
+      environmentalEffects: {
+        fog: {
+          id: 'fog',
+          name: 'Fog',
+          description: 'low visibility',
+          icon: 'f',
+          effects: {
+            druidAdvantage: { stealthBonus: 5 },
+            npcEffects: {}
+          },
+          color: '#fff'
+        }
+      }
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(data)
+    } as any);
+
+    const result = await loadEnvironmentalEffects();
+    expect(global.fetch).toHaveBeenCalledWith('/data/environments/effects.json');
+    expect(result).toEqual(data);
+  });
+
+  it('loadEnvironmentalEffects returns null on error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('fail'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await loadEnvironmentalEffects();
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/client/src/test/locationLoader.test.ts
+++ b/client/src/test/locationLoader.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadLocationData } from '../lib/locationLoader';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('locationLoader', () => {
+  it('loadLocationData parses response', async () => {
+    const data = [
+      {
+        id: 'loc1',
+        name: 'Place',
+        heat: 10,
+        hasEncounter: false,
+        position: { x: 0, y: 0 },
+        icon: 'i',
+        description: 'desc'
+      }
+    ];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(data)
+    } as any);
+    const result = await loadLocationData();
+    expect(global.fetch).toHaveBeenCalledWith('/data/locations/forest-zones.json');
+    expect(result).toEqual(data);
+  });
+
+  it('loadLocationData returns empty array on error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false } as any);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await loadLocationData();
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/client/src/test/narrativeLoader.test.ts
+++ b/client/src/test/narrativeLoader.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadNarrativeScript } from '../lib/narrativeLoader';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('narrativeLoader', () => {
+  it('loadNarrativeScript parses response', async () => {
+    const script = {
+      id: 'intro',
+      title: 'Intro',
+      startPage: 'p1',
+      pages: []
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(script)
+    } as any);
+    const result = await loadNarrativeScript('intro');
+    expect(global.fetch).toHaveBeenCalledWith('/data/narratives/intro.json');
+    expect(result).toEqual(script);
+  });
+
+  it('loadNarrativeScript returns null on error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false } as any);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await loadNarrativeScript('intro');
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `characterLoader` tests
- add `environmentLoader` tests
- add `locationLoader` tests
- add `narrativeLoader` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485c193f6883248ee56254340b18c2