### PR TITLE
Add hook tests for inventory and map events

### DIFF
--- a/client/src/test/useInventoryHook.test.ts
+++ b/client/src/test/useInventoryHook.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useInventory } from '../hooks/useInventory';
+
+// Tests for useInventory hook
+
+describe('useInventory hook', () => {
+  it('addItem adds new items and increments counts', () => {
+    const { result } = renderHook(() => useInventory());
+
+    // Increment existing item
+    act(() => {
+      result.current.addItem('healing_potion');
+    });
+    expect(result.current.getItemCount('healing_potion')).toBe(4);
+
+    // Add brand new item
+    act(() => {
+      result.current.addItem('distraction_stone');
+    });
+    expect(result.current.getItemCount('distraction_stone')).toBe(1);
+  });
+
+  it('useItem decrements and removes items', () => {
+    const { result } = renderHook(() => useInventory());
+
+    // Use item until removed
+    act(() => {
+      result.current.useItem('healing_potion');
+      result.current.useItem('healing_potion');
+      result.current.useItem('healing_potion');
+    });
+
+    expect(result.current.getItemCount('healing_potion')).toBe(0);
+    const stillExists = result.current.inventory.items.find(i => i.item.id === 'healing_potion');
+    expect(stillExists).toBeUndefined();
+
+    // Using non-existent item returns false
+    let success = true;
+    act(() => {
+      success = result.current.useItem('fake_item');
+    });
+    expect(success).toBe(false);
+  });
+});

--- a/client/src/test/useMapEvents.test.ts
+++ b/client/src/test/useMapEvents.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMapEvents } from '../hooks/useMapEvents';
+
+// Tests for useMapEvents hook
+
+describe('useMapEvents hook', () => {
+  it('appends events and formats log correctly', () => {
+    const { result } = renderHook(() => useMapEvents());
+
+    act(() => {
+      result.current.logTurnAdvance(1);
+      result.current.logEncounterStart(1, 'zone1', 'Forest');
+      result.current.logEncounterComplete(1, 'zone1', 'Forest', true);
+      result.current.logZoneChange(2, 'zone2', 'Town');
+    });
+
+    const types = result.current.mapEvents.map(e => e.type);
+    expect(types).toEqual([
+      'turn_advance',
+      'encounter_start',
+      'encounter_complete',
+      'zone_change',
+    ]);
+
+    expect(result.current.getEventLog()).toEqual([
+      'Turn 1',
+      'Encounter started in Forest',
+      'Encounter successful in Forest',
+      'Moved to Town',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `useInventory` hook logic
- add tests for `useMapEvents` hook log generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485e82369c83248385729e166f33eb