### PR TITLE
Add game engine utilities and tests

### DIFF
--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -11,6 +11,11 @@ import {
   calculatePeaceEffect,
 } from "@/lib/gameLogic";
 import { TurnManager } from "@/lib/turnManager";
+import {
+  resolvePeaceAuraEffects,
+  applyItemEffectsToState,
+  advanceTurn as advanceTurnState,
+} from "@/lib/gameEngine";
 import { loadNPCData, loadPCData } from "@/lib/characterLoader";
 import { getGlobalMapState } from "@/lib/mapState";
 import {
@@ -294,37 +299,9 @@ export function useGameState() {
       });
       const effect = calculatePeaceEffect(roll);
 
-      setGameState((prev) => {
-        const newState = { ...prev };
-        const target = newState[targetId];
-        const { stats } = target;
-
-        // Reduce target's will to fight
-        stats.willToFight = Math.max(
-          0,
-          stats.willToFight - effect.willReduction,
-        );
-
-        // Increase awareness for both NPCs (only druid actions affect awareness)
-        newState.npc1.stats.awareness = Math.min(
-          newState.npc1.stats.maxAwareness,
-          newState.npc1.stats.awareness + effect.awarenessIncrease,
-        );
-        newState.npc2.stats.awareness = Math.min(
-          newState.npc2.stats.maxAwareness,
-          newState.npc2.stats.awareness + effect.awarenessIncrease,
-        );
-
-        // Consume action point
-        newState.druid.stats.actionPoints = Math.max(
-          0,
-          newState.druid.stats.actionPoints - 1,
-        );
-
-        newState.targetingMode = false;
-
-        return newState;
-      });
+      setGameState((prev) =>
+        resolvePeaceAuraEffects(prev, targetId, effect),
+      );
 
       addLogEntry(
         `Druid uses Peace Aura on ${targetId === "npc1" ? "Gareth" : "Lyra"} (-${effect.willReduction} will, +${effect.awarenessIncrease} awareness)`,
@@ -343,17 +320,19 @@ export function useGameState() {
 
   const endTurn = useCallback(() => {
     if (turnManagerRef.current) {
-      // Reset action points when ending turn
-      setGameState((prev) => ({
-        ...prev,
-        druid: {
-          ...prev.druid,
-          actionPoints: prev.druid.stats.maxActionPoints,
-        },
-      }));
-      turnManagerRef.current.manualAdvanceTurn();
+      setGameState((prev) => {
+        if (checkGameEnd(prev)) return prev;
+        const reset = {
+          ...prev,
+          druid: {
+            ...prev.druid,
+            actionPoints: prev.druid.stats.maxActionPoints,
+          },
+        };
+        return advanceTurnState(reset);
+      });
     }
-  }, []);
+  }, [checkGameEnd]);
 
   const setTargetingMode = useCallback(
     (targeting: boolean) => {
@@ -427,71 +406,12 @@ export function useGameState() {
 
   const applyItemEffects = useCallback(
     (itemEffects: any, itemName: string) => {
-      const effectsDescription: string[] = [];
+      let effectsDescription: string[] = [];
 
       setGameState((prev) => {
-        const newState = { ...prev };
-
-        if (itemEffects.restoreAP) {
-          const apRestored = Math.min(
-            itemEffects.restoreAP,
-            newState.druid.stats.maxActionPoints -
-              newState.druid.stats.actionPoints,
-          );
-          newState.druid.stats.actionPoints = Math.min(
-            newState.druid.stats.maxActionPoints,
-            newState.druid.stats.actionPoints + itemEffects.restoreAP,
-          );
-          effectsDescription.push(`AP +${apRestored}`);
-        }
-
-        if (itemEffects.reduceAwareness) {
-          if (itemEffects.targetAll) {
-            const npc1AwarenessReduced = Math.min(
-              itemEffects.reduceAwareness,
-              newState.npc1.stats.awareness,
-            );
-            const npc2AwarenessReduced = Math.min(
-              itemEffects.reduceAwareness,
-              newState.npc2.stats.awareness,
-            );
-            newState.npc1.stats.awareness = Math.max(
-              0,
-              newState.npc1.stats.awareness - itemEffects.reduceAwareness,
-            );
-            newState.npc2.stats.awareness = Math.max(
-              0,
-              newState.npc2.stats.awareness - itemEffects.reduceAwareness,
-            );
-            effectsDescription.push(
-              `Awareness -${npc1AwarenessReduced}/-${npc2AwarenessReduced}`,
-            );
-          }
-        }
-
-        if (itemEffects.reduceWill && itemEffects.targetAll) {
-          const npc1WillReduced = Math.min(
-            itemEffects.reduceWill,
-            newState.npc1.stats.willToFight,
-          );
-          const npc2WillReduced = Math.min(
-            itemEffects.reduceWill,
-            newState.npc2.stats.willToFight,
-          );
-          newState.npc1.stats.willToFight = Math.max(
-            0,
-            newState.npc1.stats.willToFight - itemEffects.reduceWill,
-          );
-          newState.npc2.stats.willToFight = Math.max(
-            0,
-            newState.npc2.stats.willToFight - itemEffects.reduceWill,
-          );
-          effectsDescription.push(
-            `Will -${npc1WillReduced}/-${npc2WillReduced}`,
-          );
-        }
-
-        return newState;
+        const result = applyItemEffectsToState(prev, itemEffects);
+        effectsDescription = result.descriptions;
+        return result.state;
       });
 
       // Create battle event for item use

--- a/client/src/lib/gameEngine.ts
+++ b/client/src/lib/gameEngine.ts
@@ -1,0 +1,115 @@
+import type { GameState, PeaceEffect } from './gameLogic';
+import type { ItemEffect } from './inventory';
+
+/**
+ * Apply the results of a Peace Aura action to the game state.
+ * This function is pure and does not mutate the original state.
+ */
+export function resolvePeaceAuraEffects(
+  state: GameState,
+  targetId: 'npc1' | 'npc2',
+  effect: PeaceEffect,
+): GameState {
+  const newState: GameState = {
+    ...state,
+    npc1: { ...state.npc1, stats: { ...state.npc1.stats } },
+    npc2: { ...state.npc2, stats: { ...state.npc2.stats } },
+    druid: { ...state.druid, stats: { ...state.druid.stats } },
+  };
+
+  const target = newState[targetId];
+  target.stats.willToFight = Math.max(0, target.stats.willToFight - effect.willReduction);
+
+  newState.npc1.stats.awareness = Math.min(
+    newState.npc1.stats.maxAwareness,
+    newState.npc1.stats.awareness + effect.awarenessIncrease,
+  );
+  newState.npc2.stats.awareness = Math.min(
+    newState.npc2.stats.maxAwareness,
+    newState.npc2.stats.awareness + effect.awarenessIncrease,
+  );
+
+  newState.druid.stats.actionPoints = Math.max(0, newState.druid.stats.actionPoints - 1);
+  newState.targetingMode = false;
+
+  return newState;
+}
+
+/**
+ * Apply item effects to the game state. Returns the updated state and a
+ * description of the effects applied for logging purposes.
+ */
+export function applyItemEffectsToState(
+  state: GameState,
+  itemEffects: ItemEffect,
+): { state: GameState; descriptions: string[] } {
+  const newState: GameState = {
+    ...state,
+    npc1: { ...state.npc1, stats: { ...state.npc1.stats } },
+    npc2: { ...state.npc2, stats: { ...state.npc2.stats } },
+    druid: { ...state.druid, stats: { ...state.druid.stats } },
+  };
+  const descriptions: string[] = [];
+
+  if (itemEffects.restoreAP) {
+    const apRestored = Math.min(
+      itemEffects.restoreAP,
+      newState.druid.stats.maxActionPoints - newState.druid.stats.actionPoints,
+    );
+    newState.druid.stats.actionPoints = Math.min(
+      newState.druid.stats.maxActionPoints,
+      newState.druid.stats.actionPoints + itemEffects.restoreAP,
+    );
+    descriptions.push(`AP +${apRestored}`);
+  }
+
+  if (itemEffects.reduceAwareness && itemEffects.targetAll) {
+    const npc1Reduced = Math.min(itemEffects.reduceAwareness, newState.npc1.stats.awareness);
+    const npc2Reduced = Math.min(itemEffects.reduceAwareness, newState.npc2.stats.awareness);
+    newState.npc1.stats.awareness = Math.max(
+      0,
+      newState.npc1.stats.awareness - itemEffects.reduceAwareness,
+    );
+    newState.npc2.stats.awareness = Math.max(
+      0,
+      newState.npc2.stats.awareness - itemEffects.reduceAwareness,
+    );
+    descriptions.push(`Awareness -${npc1Reduced}/-${npc2Reduced}`);
+  }
+
+  if (itemEffects.reduceWill && itemEffects.targetAll) {
+    const npc1WillReduced = Math.min(itemEffects.reduceWill, newState.npc1.stats.willToFight);
+    const npc2WillReduced = Math.min(itemEffects.reduceWill, newState.npc2.stats.willToFight);
+    newState.npc1.stats.willToFight = Math.max(
+      0,
+      newState.npc1.stats.willToFight - itemEffects.reduceWill,
+    );
+    newState.npc2.stats.willToFight = Math.max(
+      0,
+      newState.npc2.stats.willToFight - itemEffects.reduceWill,
+    );
+    descriptions.push(`Will -${npc1WillReduced}/-${npc2WillReduced}`);
+  }
+
+  return { state: newState, descriptions };
+}
+
+/**
+ * Advance the turn order. Returns a new game state with the currentTurn and
+ * turnCounter updated.
+ */
+export function advanceTurn(state: GameState): GameState {
+  let newTurn: 'npc1' | 'npc2' | 'druid';
+  let newTurnCounter = state.turnCounter;
+
+  if (state.currentTurn === 'npc1') {
+    newTurn = 'npc2';
+  } else if (state.currentTurn === 'npc2') {
+    newTurn = 'druid';
+  } else {
+    newTurn = 'npc1';
+    newTurnCounter++;
+  }
+
+  return { ...state, currentTurn: newTurn, turnCounter: newTurnCounter };
+}

--- a/client/src/test/gameEngine.test.ts
+++ b/client/src/test/gameEngine.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePeaceAuraEffects, applyItemEffectsToState, advanceTurn } from '../lib/gameEngine';
+import type { GameState } from '../lib/gameLogic';
+import type { ItemEffect } from '../lib/inventory';
+
+function createBaseState(currentTurn: 'npc1' | 'npc2' | 'druid', turnCounter = 1): GameState {
+  return {
+    currentTurn,
+    turnCounter,
+    npc1: {
+      id: 'npc1',
+      name: 'NPC 1',
+      icon: '',
+      color: '',
+      description: '',
+      position: 'left',
+      stats: {
+        health: 10,
+        maxHealth: 10,
+        armor: 0,
+        maxArmor: 0,
+        willToFight: 10,
+        maxWill: 10,
+        awareness: 5,
+        maxAwareness: 100,
+      },
+      actions: [],
+    },
+    npc2: {
+      id: 'npc2',
+      name: 'NPC 2',
+      icon: '',
+      color: '',
+      description: '',
+      position: 'right',
+      stats: {
+        health: 10,
+        maxHealth: 10,
+        armor: 0,
+        maxArmor: 0,
+        willToFight: 10,
+        maxWill: 10,
+        awareness: 5,
+        maxAwareness: 100,
+      },
+      actions: [],
+    },
+    druid: {
+      id: 'druid',
+      name: 'Druid',
+      icon: '',
+      color: '',
+      stats: {
+        hidden: true,
+        actionPoints: 3,
+        maxActionPoints: 3,
+      },
+      abilities: [],
+    },
+    gameOver: false,
+    targetingMode: true,
+    combatLog: [],
+    gameOverState: null,
+  };
+}
+
+describe('gameEngine', () => {
+  it('resolvePeaceAuraEffects applies effects correctly', () => {
+    const state = createBaseState('druid');
+    const effect = { willReduction: 4, awarenessIncrease: 2 };
+    const result = resolvePeaceAuraEffects(state, 'npc1', effect);
+
+    expect(result.npc1.stats.willToFight).toBe(6);
+    expect(result.npc1.stats.awareness).toBe(7);
+    expect(result.npc2.stats.awareness).toBe(7);
+    expect(result.druid.stats.actionPoints).toBe(2);
+    expect(result.targetingMode).toBe(false);
+  });
+
+  it('applyItemEffectsToState modifies state and returns descriptions', () => {
+    const state = createBaseState('druid');
+    const effects: ItemEffect = { restoreAP: 2, reduceAwareness: 3, reduceWill: 2, targetAll: true };
+    const { state: newState, descriptions } = applyItemEffectsToState(state, effects);
+
+    expect(newState.druid.stats.actionPoints).toBe(3); // capped at max 3
+    expect(newState.npc1.stats.awareness).toBe(2);
+    expect(newState.npc2.stats.awareness).toBe(2);
+    expect(newState.npc1.stats.willToFight).toBe(8);
+    expect(newState.npc2.stats.willToFight).toBe(8);
+    expect(descriptions.length).toBeGreaterThan(0);
+  });
+
+  it('advanceTurn cycles turns correctly', () => {
+    let state = createBaseState('npc1', 1);
+    state = advanceTurn(state);
+    expect(state.currentTurn).toBe('npc2');
+    expect(state.turnCounter).toBe(1);
+
+    state = advanceTurn(state);
+    expect(state.currentTurn).toBe('druid');
+    expect(state.turnCounter).toBe(1);
+
+    state = advanceTurn(state);
+    expect(state.currentTurn).toBe('npc1');
+    expect(state.turnCounter).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `gameEngine` module with helpers for peace aura, item use and turn order
- update `useGameState` to use the new helpers
- provide unit tests for the new game engine functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485ed3178083249905d1e328f03225