### PR TITLE
Refactor modals and controls with shadcn/ui

### DIFF
--- a/client/src/components/HistoryDebugModal.tsx
+++ b/client/src/components/HistoryDebugModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { X, Calendar, User, Trophy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { globalHistoryManager, PCHistoryStore, EncounterHistory, PlayerAction } from '@/lib/historySystem';
@@ -23,21 +24,17 @@ export default function HistoryDebugModal({ onClose }: HistoryDebugModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-75 flex items-center justify-center p-4">
-      <div className="bg-gray-900 border-2 border-amber-400 rounded-lg max-w-4xl w-full max-h-[80vh] overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-700">
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="bg-gray-900 border-2 border-amber-400 rounded-lg max-w-4xl w-full max-h-[80vh] overflow-hidden">
+        <DialogHeader className="flex items-center justify-between p-4 border-b border-gray-700">
           <div className="flex items-center gap-2">
             <Calendar className="w-5 h-5 text-amber-400" />
-            <h2 className="text-xl font-bold text-amber-400 font-mono">PC HISTORY</h2>
+            <DialogTitle className="text-xl font-bold text-amber-400 font-mono">PC HISTORY</DialogTitle>
           </div>
-          <Button
-            onClick={onClose}
-            className="bg-red-600 hover:bg-red-700 text-white p-1 h-8 w-8"
-          >
+          <Button onClick={onClose} className="bg-red-600 hover:bg-red-700 text-white p-1 h-8 w-8">
             <X className="w-4 h-4" />
           </Button>
-        </div>
+        </DialogHeader>
 
         <div className="p-4 overflow-auto max-h-[calc(80vh-100px)]">
           {/* Statistics */}
@@ -157,7 +154,7 @@ export default function HistoryDebugModal({ onClose }: HistoryDebugModalProps) {
             )}
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/SkillRequirementsModal.tsx
+++ b/client/src/components/SkillRequirementsModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { X, Target, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { globalSkillManager, SkillNode } from '@/lib/skillTreeLoader';
@@ -59,21 +60,17 @@ export default function SkillRequirementsModal({ onClose }: SkillRequirementsMod
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-75 flex items-center justify-center p-4">
-      <div className="bg-gray-900 border-2 border-amber-400 rounded-lg max-w-3xl w-full max-h-[80vh] overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-700">
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="bg-gray-900 border-2 border-amber-400 rounded-lg max-w-3xl w-full max-h-[80vh] overflow-hidden">
+        <DialogHeader className="flex items-center justify-between p-4 border-b border-gray-700">
           <div className="flex items-center gap-2">
             <Target className="w-5 h-5 text-amber-400" />
-            <h2 className="text-xl font-bold text-amber-400 font-mono">SKILL REQUIREMENTS</h2>
+            <DialogTitle className="text-xl font-bold text-amber-400 font-mono">SKILL REQUIREMENTS</DialogTitle>
           </div>
-          <Button
-            onClick={onClose}
-            className="bg-red-600 hover:bg-red-700 text-white p-1 h-8 w-8"
-          >
+          <Button onClick={onClose} className="bg-red-600 hover:bg-red-700 text-white p-1 h-8 w-8">
             <X className="w-4 h-4" />
           </Button>
-        </div>
+        </DialogHeader>
 
         <div className="p-4 overflow-auto max-h-[calc(80vh-100px)]">
           {skills.length === 0 ? (
@@ -153,7 +150,7 @@ export default function SkillRequirementsModal({ onClose }: SkillRequirementsMod
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/game/GameOverModal.tsx
+++ b/client/src/components/game/GameOverModal.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useLocation } from "wouter";
 import { getGlobalMapState } from "@/lib/mapState";
 
@@ -13,8 +14,6 @@ interface GameOverModalProps {
 export default function GameOverModal({ visible, title, message, icon, onRestart }: GameOverModalProps) {
   const [, setLocation] = useLocation();
   
-  if (!visible) return null;
-
   const handleReturnToMap = () => {
     // Determine if encounter was successful based on game outcome
     const isSuccess = title === "PEACE ACHIEVED";
@@ -34,20 +33,22 @@ export default function GameOverModal({ visible, title, message, icon, onRestart
   };
 
   return (
-    <div className="absolute inset-0 bg-black bg-opacity-80 z-50 flex items-center justify-center">
-      <div className="bg-gray-900 rounded-lg p-8 border-4 border-yellow-400 max-w-md">
+    <Dialog open={visible}>
+      <DialogContent className="bg-gray-900 border-4 border-yellow-400 max-w-md">
+        <DialogHeader className="text-center space-y-4">
+          <div className="text-6xl">{icon}</div>
+          <DialogTitle className="font-mono text-yellow-400 text-xl">{title}</DialogTitle>
+        </DialogHeader>
+        <p className="text-gray-300 mb-6 text-center">{message}</p>
         <div className="text-center">
-          <div className="text-6xl mb-4">{icon}</div>
-          <h2 className="font-mono text-yellow-400 text-xl mb-4">{title}</h2>
-          <p className="text-gray-300 mb-6">{message}</p>
-          <Button 
+          <Button
             onClick={handleReturnToMap}
-            className="bg-yellow-400 hover:bg-yellow-300 text-gray-900 font-mono py-3 px-6 rounded transition-colors duration-200"
+            className="bg-yellow-400 hover:bg-yellow-300 text-gray-900 font-mono py-3 px-6 transition-colors duration-200"
           >
             RETURN TO MAP
           </Button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/inventory/InventoryScreen.tsx
+++ b/client/src/components/inventory/InventoryScreen.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip';
 import { useInventory } from '@/hooks/useInventory';
 import { loadItems } from '@/lib/inventory';
 import { IS_DEBUG } from '@/lib/debug';
@@ -112,38 +118,35 @@ export default function InventoryScreen({ isModal = false, onClose, onUseItem }:
               <div className="text-gray-400 mt-2">Collect items during your adventures</div>
             </div>
           ) : (
-            <div className="grid grid-cols-6 gap-4">
-              {inventory.items.map((invItem) => (
-                <div
-                  key={invItem.item.id}
-                  className="relative group"
-                >
-                  <Button
-                    onClick={() => handleUseItem(invItem.item.id)}
-                    className="w-full h-24 bg-gray-800 hover:bg-gray-700 border-2 border-gray-600 hover:border-amber-400 text-white flex flex-col items-center justify-center p-2 transition-all duration-200"
-                    title={invItem.item.description}
-                    disabled={!onUseItem}
-                  >
-                    <div className="text-2xl mb-1">{invItem.item.icon}</div>
-                    <div className="text-xs font-mono text-center leading-tight">{invItem.item.name}</div>
-                    
-                    {/* Stack count */}
-                    {invItem.count > 1 && (
-                      <div className="absolute -top-2 -right-2 bg-amber-600 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
-                        {invItem.count}
-                      </div>
-                    )}
-                  </Button>
+            <TooltipProvider delayDuration={0}>
+              <div className="grid grid-cols-6 gap-4">
+                {inventory.items.map((invItem) => (
+                  <Tooltip key={invItem.item.id}>
+                    <TooltipTrigger asChild>
+                      <div className="relative group">
+                        <Button
+                          onClick={() => handleUseItem(invItem.item.id)}
+                          className="w-full h-24 bg-gray-800 hover:bg-gray-700 border-2 border-gray-600 hover:border-amber-400 text-white flex flex-col items-center justify-center p-2 transition-all duration-200"
+                          title={invItem.item.description}
+                          disabled={!onUseItem}
+                        >
+                          <div className="text-2xl mb-1">{invItem.item.icon}</div>
+                          <div className="text-xs font-mono text-center leading-tight">{invItem.item.name}</div>
 
-                  {/* Tooltip */}
-                  <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
-                    <div className="bg-gray-900 text-white text-xs rounded px-2 py-1 border border-gray-600 whitespace-nowrap">
-                      {invItem.item.description}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+                          {/* Stack count */}
+                          {invItem.count > 1 && (
+                            <div className="absolute -top-2 -right-2 bg-amber-600 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
+                              {invItem.count}
+                            </div>
+                          )}
+                        </Button>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>{invItem.item.description}</TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+            </TooltipProvider>
           )}
         </div>
       </div>

--- a/client/src/components/map/HeatBar.tsx
+++ b/client/src/components/map/HeatBar.tsx
@@ -1,4 +1,11 @@
 import { cn } from "@/lib/utils";
+import { Progress } from "@/components/ui/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
 
 interface HeatBarProps {
   heat: number;
@@ -25,36 +32,27 @@ function getHeatColor(heat: number): string {
 export default function HeatBar({ heat }: HeatBarProps) {
   const level = getHeatLevel(heat);
   const colorClass = getHeatColor(heat);
-  
+
   return (
-    <div 
-      className="relative group"
-      title={`Heat: ${heat} – ${level}. Higher heat makes conflict more likely.`}
-    >
-      {/* Heat Bar Background */}
-      <div className="w-16 h-2 bg-gray-300 rounded-full border border-gray-400">
-        {/* Heat Bar Fill */}
-        <div 
-          className={cn(
-            "h-full rounded-full transition-all duration-500",
-            colorClass,
-            heat >= 90 && "animate-pulse"
-          )}
-          style={{ width: `${heat}%` }}
-        />
-      </div>
-      
-      {/* Heat Value */}
-      <div className="text-xs text-white font-mono text-center mt-1 bg-black bg-opacity-70 rounded px-1">
-        {heat}
-      </div>
-      
-      {/* Tooltip on Hover */}
-      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-black text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap z-50">
-        Heat: {heat} – {level}
-        <br />
-        Higher heat makes conflict more likely
-      </div>
-    </div>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="relative inline-flex flex-col items-center">
+            <Progress
+              value={heat}
+              className="w-16 h-2 bg-gray-300 border border-gray-400"
+              indicatorClassName={cn(colorClass, "transition-all", heat >= 90 && "animate-pulse")}
+            />
+            <div className="text-xs text-white font-mono text-center mt-1 bg-black bg-opacity-70 rounded px-1">
+              {heat}
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent className="whitespace-pre-line text-center">
+          Heat: {heat} – {level}
+          {"\n"}Higher heat makes conflict more likely
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        menu:
+          "w-full font-mono text-white border-2 shadow-lg transition-all duration-200 hover:scale-105",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/client/src/components/ui/progress.tsx
+++ b/client/src/components/ui/progress.tsx
@@ -5,10 +5,15 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+interface ProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, indicatorClassName, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +23,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn(
+        "h-full w-full flex-1 bg-primary transition-all",
+        indicatorClassName
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/client/src/pages/main-menu.tsx
+++ b/client/src/pages/main-menu.tsx
@@ -79,21 +79,24 @@ export default function MainMenu() {
           <Button
             onClick={handleNewGame}
             disabled={loading}
-            className="w-full h-14 text-xl font-mono bg-emerald-600 hover:bg-emerald-700 border-2 border-emerald-400 text-white shadow-lg transition-all duration-200 hover:scale-105 disabled:opacity-50"
+            variant="menu"
+            className="h-14 text-xl bg-emerald-600 hover:bg-emerald-700 border-emerald-400 disabled:opacity-50"
           >
             {loading ? "🌱 LOADING..." : "🌱 NEW GAME"}
           </Button>
           
           <Button
             onClick={handleContinueGame}
-            className="w-full h-14 text-xl font-mono bg-green-600 hover:bg-green-700 border-2 border-green-400 text-white shadow-lg transition-all duration-200 hover:scale-105"
+            variant="menu"
+            className="h-14 text-xl bg-green-600 hover:bg-green-700 border-green-400"
           >
             🗺️ CONTINUE GAME
           </Button>
           
           <Button
             onClick={() => {/* TODO: Settings */}}
-            className="w-full h-12 text-lg font-mono bg-green-700 hover:bg-green-800 border-2 border-green-500 text-white shadow-lg transition-all duration-200 hover:scale-105"
+            variant="menu"
+            className="h-12 text-lg bg-green-700 hover:bg-green-800 border-green-500"
             disabled
           >
             ⚙️ SETTINGS
@@ -101,7 +104,8 @@ export default function MainMenu() {
           
           <Button
             onClick={() => {/* TODO: Credits */}}
-            className="w-full h-12 text-lg font-mono bg-green-700 hover:bg-green-800 border-2 border-green-500 text-white shadow-lg transition-all duration-200 hover:scale-105"
+            variant="menu"
+            className="h-12 text-lg bg-green-700 hover:bg-green-800 border-green-500"
             disabled
           >
             📜 CREDITS


### PR DESCRIPTION
## Summary
- convert bespoke modals to `Dialog`
- add `menu` variant to button component and use in main menu
- replace custom tooltip and progress bar with shadcn versions
- expose progress indicator class override

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_684888357870832486c8003579747d52