### PR TITLE
Add mapState tests

### DIFF
--- a/client/src/test/mapState.test.ts
+++ b/client/src/test/mapState.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('mapState', () => {
+  it('setGlobalMapState stores provided object and getGlobalMapState returns it', async () => {
+    const mod = await import('../lib/mapState');
+    const { setGlobalMapState, getGlobalMapState } = mod;
+    const state = { resolveEncounter: vi.fn(), currentEncounterZone: 'zone1' };
+    setGlobalMapState(state);
+    expect(getGlobalMapState()).toBe(state);
+  });
+
+  it('setCurrentEncounterZone updates currentEncounterZone', async () => {
+    const mod = await import('../lib/mapState');
+    const { setGlobalMapState, getGlobalMapState, setCurrentEncounterZone, getCurrentEncounterZone } = mod;
+    const state = { resolveEncounter: vi.fn(), currentEncounterZone: 'start' };
+    setGlobalMapState(state);
+    setCurrentEncounterZone('zone2');
+    expect(getCurrentEncounterZone()).toBe('zone2');
+    expect(getGlobalMapState().currentEncounterZone).toBe('zone2');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for mapState helper functions

## Testing
- `npm run tests`


------
https://chatgpt.com/codex/tasks/task_e_68489a61d6c083249f821066b6fc0227