### PR TITLE
Refactor GameBoard UI sections

### DIFF
--- a/client/src/components/game/ActionPanel.tsx
+++ b/client/src/components/game/ActionPanel.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PCAbility } from "@/lib/characterLoader";
+
+interface ActionPanelProps {
+  abilities: PCAbility[];
+  actionPoints: number;
+  canUseActions: boolean;
+  onAbilityUse: (abilityKey: string) => void;
+}
+
+export default function ActionPanel({
+  abilities,
+  actionPoints,
+  canUseActions,
+  onAbilityUse,
+}: ActionPanelProps) {
+  return (
+    <div className="flex space-x-4">
+      {abilities.map((ability) => (
+        <Button
+          key={ability.key}
+          onClick={() => onAbilityUse(ability.key)}
+          disabled={
+            !canUseActions ||
+            actionPoints <= 0 ||
+            ability.cost > actionPoints
+          }
+          className={cn(
+            "w-12 h-12 text-2xl border-2 transition-all duration-200",
+            canUseActions &&
+              actionPoints > 0 &&
+              ability.cost <= actionPoints
+              ? "bg-green-600 hover:bg-green-700 border-green-400 text-white"
+              : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
+          )}
+          title={`${ability.name}: ${ability.description} (Cost: ${ability.cost})`}
+        >
+          {ability.icon}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/game/DebugPanel.tsx
+++ b/client/src/components/game/DebugPanel.tsx
@@ -1,0 +1,96 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { IS_DEBUG, DebugState } from "@/lib/debug";
+import { Play, Pause, Sword, Shield } from "lucide-react";
+
+interface DebugPanelProps {
+  visible: boolean;
+  debugState: DebugState;
+  onToggleAutoTurn: () => void;
+  onNPCAction: (npcId: "npc1" | "npc2", action: "attack" | "defend") => void;
+}
+
+export default function DebugPanel({
+  visible,
+  debugState,
+  onToggleAutoTurn,
+  onNPCAction,
+}: DebugPanelProps) {
+  if (!IS_DEBUG || !visible) return null;
+
+  return (
+    <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50">
+      <div className="bg-gray-900 rounded-lg p-4 shadow-lg border-2 border-yellow-400 min-w-64">
+        <div className="text-center mb-3">
+          <div className="text-sm font-mono text-yellow-400">DEBUG CONTROLS</div>
+        </div>
+        <div className="flex flex-col gap-3">
+          <Button
+            onClick={onToggleAutoTurn}
+            className={cn(
+              "w-full h-10 text-sm border-2 transition-all duration-200",
+              debugState.autoTurn
+                ? "bg-green-600 hover:bg-green-700 border-green-400 text-white"
+                : "bg-red-600 hover:bg-red-700 border-red-400 text-white",
+            )}
+            title="Toggle automatic NPC turns"
+          >
+            {debugState.autoTurn ? (
+              <Play className="w-4 h-4 mr-2" />
+            ) : (
+              <Pause className="w-4 h-4 mr-2" />
+            )}
+            Auto Turn: {debugState.autoTurn ? "ON" : "OFF"}
+          </Button>
+          {!debugState.autoTurn && (
+            <>
+              <div className="text-xs font-mono text-gray-400 text-center mt-2">
+                MANUAL NPC ACTIONS
+              </div>
+              <div className="space-y-2">
+                <div className="text-xs font-mono text-white">Gareth (NPC1)</div>
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => onNPCAction("npc1", "attack")}
+                    className="flex-1 h-8 text-xs bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
+                    title="Gareth Attack"
+                  >
+                    <Sword className="w-3 h-3 mr-1" />
+                    Attack
+                  </Button>
+                  <Button
+                    onClick={() => onNPCAction("npc1", "defend")}
+                    className="flex-1 h-8 text-xs bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
+                    title="Gareth Defend"
+                  >
+                    <Shield className="w-3 h-3 mr-1" />
+                    Defend
+                  </Button>
+                </div>
+                <div className="text-xs font-mono text-white">Lyra (NPC2)</div>
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => onNPCAction("npc2", "attack")}
+                    className="flex-1 h-8 text-xs bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
+                    title="Lyra Attack"
+                  >
+                    <Sword className="w-3 h-3 mr-1" />
+                    Attack
+                  </Button>
+                  <Button
+                    onClick={() => onNPCAction("npc2", "defend")}
+                    className="flex-1 h-8 text-xs bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
+                    title="Lyra Defend"
+                  >
+                    <Shield className="w-3 h-3 mr-1" />
+                    Defend
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/game/GameBoard.tsx
+++ b/client/src/components/game/GameBoard.tsx
@@ -7,6 +7,9 @@ import DiceDisplay from "./DiceDisplay";
 import GameOverModal from "./GameOverModal";
 import CombatLog from "./CombatLog";
 import InventoryScreen from "@/components/inventory/InventoryScreen";
+import ActionPanel from "./ActionPanel";
+import StatusBar from "./StatusBar";
+import DebugPanel from "./DebugPanel";
 import {
   loadNPCData,
   loadPCData,
@@ -14,22 +17,8 @@ import {
   PCCharacterData,
 } from "@/lib/characterLoader";
 import { useInventory } from "@/hooks/useInventory";
-import { getItemById, ItemEffect } from "@/lib/inventory";
-import { globalHistoryManager } from "@/lib/historySystem";
-import { globalWeatherManager } from "@/lib/weatherSystem";
-import { Button } from "@/components/ui/button";
-import {
-  Eye,
-  EyeOff,
-  Minimize2,
-  Settings,
-  Play,
-  Pause,
-  Sword,
-  Shield,
-  Package,
-} from "lucide-react";
-import { cn } from "@/lib/utils";
+import { getItemById } from "@/lib/inventory";
+
 import { IS_DEBUG, initialDebugState, DebugState } from "@/lib/debug";
 import {
   globalTimeManager,
@@ -198,21 +187,6 @@ export default function GameBoard() {
   const canUseActions =
     gameState.currentTurn === "druid" && !gameState.targetingMode;
 
-  const getCombatLogIcon = () => {
-    switch (combatLogMode) {
-      case "hidden":
-        return EyeOff;
-      case "small":
-        return Eye;
-      case "large":
-        return Minimize2;
-      default:
-        return Eye;
-    }
-  };
-
-  const CombatLogIcon = getCombatLogIcon();
-
   // Show loading state while character data loads
   if (!dataLoaded || !pcData) {
     return (
@@ -330,209 +304,37 @@ export default function GameBoard() {
 
             {/* Center - Abilities */}
             <div className="flex-1 flex justify-center">
-              <div className="flex space-x-4">
-                {pcData?.abilities.map((ability) => (
-                  <Button
-                    key={ability.key}
-                    onClick={() => handleAbilityUse(ability.key)}
-                    disabled={
-                      !canUseActions ||
-                      !hasActionPoints ||
-                      ability.cost > gameState.druid.stats.actionPoints
-                    }
-                    className={cn(
-                      "w-12 h-12 text-2xl border-2 transition-all duration-200",
-                      canUseActions &&
-                        hasActionPoints &&
-                        ability.cost <= gameState.druid.stats.actionPoints
-                        ? "bg-green-600 hover:bg-green-700 border-green-400 text-white"
-                        : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
-                    )}
-                    title={`${ability.name}: ${ability.description} (Cost: ${ability.cost})`}
-                  >
-                    {ability.icon}
-                  </Button>
-                ))}
-              </div>
+              <ActionPanel
+                abilities={pcData?.abilities || []}
+                actionPoints={gameState.druid.stats.actionPoints}
+                canUseActions={canUseActions}
+                onAbilityUse={handleAbilityUse}
+              />
             </div>
 
             {/* Right side - Utils and Status */}
-            <div className="flex items-center space-x-4">
-              {/* Status Info */}
-              <div className="text-right mr-4">
-                <div className="text-xs font-mono text-orange-200 mb-1">
-                  STATUS
-                </div>
-                <div className="text-sm font-mono text-white">
-                  {gameState.targetingMode ? "🎯 TARGETING" : "✋ READY"}
-                </div>
-              </div>
-
-              {/* Utils Section */}
-              <div className="flex items-center space-x-2 border-l border-orange-300 pl-4">
-                {/* Combat Log Toggle */}
-                <Button
-                  onClick={toggleCombatLog}
-                  className="w-12 h-12 bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
-                  title={`Combat Log: ${combatLogMode}`}
-                >
-                  <CombatLogIcon className="w-5 h-5" />
-                </Button>
-
-                {/* Use Item */}
-                <Button
-                  onClick={() => setShowInventoryModal(true)}
-                  disabled={!canUseActions}
-                  className={cn(
-                    "w-12 h-12 border-2 transition-all duration-200",
-                    canUseActions
-                      ? "bg-amber-600 hover:bg-amber-700 border-amber-400 text-white"
-                      : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
-                  )}
-                  title="Use Item"
-                >
-                  <Package className="w-5 h-5" />
-                </Button>
-
-                {/* Debug Toggle */}
-                {IS_DEBUG && (
-                  <Button
-                    onClick={() => setShowDebugPanel(!showDebugPanel)}
-                    className={cn(
-                      "w-12 h-12 border-2 transition-all duration-200",
-                      showDebugPanel
-                        ? "bg-yellow-700 border-yellow-500 text-white"
-                        : "bg-yellow-600 hover:bg-yellow-700 border-yellow-400 text-white",
-                    )}
-                    title="Toggle debug panel"
-                  >
-                    <Settings className="w-5 h-5" />
-                  </Button>
-                )}
-
-                {/* End Turn */}
-                <Button
-                  onClick={handleEndTurn}
-                  disabled={!canUseActions}
-                  className={cn(
-                    "w-12 h-12 border-2 transition-all duration-200",
-                    canUseActions
-                      ? "bg-orange-600 hover:bg-orange-700 border-orange-400 text-white"
-                      : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
-                  )}
-                  title="End Turn"
-                >
-                  ⏰
-                </Button>
-
-                {/* Flee */}
-                <Button
-                  onClick={handleFleeAbility}
-                  disabled={!canUseActions}
-                  className={cn(
-                    "w-12 h-12 border-2 transition-all duration-200",
-                    canUseActions
-                      ? "bg-red-600 hover:bg-red-700 border-red-400 text-white"
-                      : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
-                  )}
-                  title="Flee from encounter"
-                >
-                  🏃
-                </Button>
-              </div>
-            </div>
+            <StatusBar
+              targetingMode={gameState.targetingMode}
+              canUseActions={canUseActions}
+              combatLogMode={combatLogMode}
+              showDebugPanel={showDebugPanel}
+              onToggleCombatLog={toggleCombatLog}
+              onToggleDebug={() => setShowDebugPanel(!showDebugPanel)}
+              onEndTurn={handleEndTurn}
+              onFlee={handleFleeAbility}
+              onOpenInventory={() => setShowInventoryModal(true)}
+            />
           </div>
         </div>
       </div>
 
       {/* Debug Panel - Center of Battle Area */}
-      {IS_DEBUG && showDebugPanel && (
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50">
-          <div className="bg-gray-900 rounded-lg p-4 shadow-lg border-2 border-yellow-400 min-w-64">
-            <div className="text-center mb-3">
-              <div className="text-sm font-mono text-yellow-400">
-                DEBUG CONTROLS
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3">
-              {/* Auto Turn Toggle */}
-              <Button
-                onClick={toggleAutoTurn}
-                className={cn(
-                  "w-full h-10 text-sm border-2 transition-all duration-200",
-                  debugState.autoTurn
-                    ? "bg-green-600 hover:bg-green-700 border-green-400 text-white"
-                    : "bg-red-600 hover:bg-red-700 border-red-400 text-white",
-                )}
-                title="Toggle automatic NPC turns"
-              >
-                {debugState.autoTurn ? (
-                  <Play className="w-4 h-4 mr-2" />
-                ) : (
-                  <Pause className="w-4 h-4 mr-2" />
-                )}
-                Auto Turn: {debugState.autoTurn ? "ON" : "OFF"}
-              </Button>
-
-              {/* NPC Action Buttons */}
-              {!debugState.autoTurn && (
-                <>
-                  <div className="text-xs font-mono text-gray-400 text-center mt-2">
-                    MANUAL NPC ACTIONS
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="text-xs font-mono text-white">
-                      Gareth (NPC1)
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        onClick={() => handleDebugNPCAction("npc1", "attack")}
-                        className="flex-1 h-8 text-xs bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
-                        title="Gareth Attack"
-                      >
-                        <Sword className="w-3 h-3 mr-1" />
-                        Attack
-                      </Button>
-                      <Button
-                        onClick={() => handleDebugNPCAction("npc1", "defend")}
-                        className="flex-1 h-8 text-xs bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
-                        title="Gareth Defend"
-                      >
-                        <Shield className="w-3 h-3 mr-1" />
-                        Defend
-                      </Button>
-                    </div>
-
-                    <div className="text-xs font-mono text-white">
-                      Lyra (NPC2)
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        onClick={() => handleDebugNPCAction("npc2", "attack")}
-                        className="flex-1 h-8 text-xs bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
-                        title="Lyra Attack"
-                      >
-                        <Sword className="w-3 h-3 mr-1" />
-                        Attack
-                      </Button>
-                      <Button
-                        onClick={() => handleDebugNPCAction("npc2", "defend")}
-                        className="flex-1 h-8 text-xs bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
-                        title="Lyra Defend"
-                      >
-                        <Shield className="w-3 h-3 mr-1" />
-                        Defend
-                      </Button>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
+      <DebugPanel
+        visible={showDebugPanel}
+        debugState={debugState}
+        onToggleAutoTurn={toggleAutoTurn}
+        onNPCAction={handleDebugNPCAction}
+      />
 
       {/* Dice Display */}
       <DiceDisplay

--- a/client/src/components/game/StatusBar.tsx
+++ b/client/src/components/game/StatusBar.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { IS_DEBUG } from "@/lib/debug";
+import {
+  Eye,
+  EyeOff,
+  Minimize2,
+  Settings,
+  Package,
+} from "lucide-react";
+import type { ReactElement } from "react";
+
+interface StatusBarProps {
+  targetingMode: boolean;
+  canUseActions: boolean;
+  combatLogMode: "hidden" | "small" | "large";
+  showDebugPanel: boolean;
+  onToggleCombatLog: () => void;
+  onToggleDebug: () => void;
+  onEndTurn: () => void;
+  onFlee: () => void;
+  onOpenInventory: () => void;
+}
+
+export default function StatusBar({
+  targetingMode,
+  canUseActions,
+  combatLogMode,
+  showDebugPanel,
+  onToggleCombatLog,
+  onToggleDebug,
+  onEndTurn,
+  onFlee,
+  onOpenInventory,
+}: StatusBarProps) {
+  const getCombatLogIcon = (): ReactElement => {
+    switch (combatLogMode) {
+      case "hidden":
+        return <EyeOff className="w-5 h-5" />;
+      case "small":
+        return <Eye className="w-5 h-5" />;
+      case "large":
+        return <Minimize2 className="w-5 h-5" />;
+      default:
+        return <Eye className="w-5 h-5" />;
+    }
+  };
+
+  return (
+    <div className="flex items-center space-x-4">
+      <div className="text-right mr-4">
+        <div className="text-xs font-mono text-orange-200 mb-1">STATUS</div>
+        <div className="text-sm font-mono text-white">
+          {targetingMode ? "🎯 TARGETING" : "✋ READY"}
+        </div>
+      </div>
+      <div className="flex items-center space-x-2 border-l border-orange-300 pl-4">
+        <Button
+          onClick={onToggleCombatLog}
+          className="w-12 h-12 bg-blue-600 hover:bg-blue-700 border-2 border-blue-400 text-white"
+          title={`Combat Log: ${combatLogMode}`}
+        >
+          {getCombatLogIcon()}
+        </Button>
+        <Button
+          onClick={onOpenInventory}
+          disabled={!canUseActions}
+          className={cn(
+            "w-12 h-12 border-2 transition-all duration-200",
+            canUseActions
+              ? "bg-amber-600 hover:bg-amber-700 border-amber-400 text-white"
+              : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
+          )}
+          title="Use Item"
+        >
+          <Package className="w-5 h-5" />
+        </Button>
+        {IS_DEBUG && (
+          <Button
+            onClick={onToggleDebug}
+            className={cn(
+              "w-12 h-12 border-2 transition-all duration-200",
+              showDebugPanel
+                ? "bg-yellow-700 border-yellow-500 text-white"
+                : "bg-yellow-600 hover:bg-yellow-700 border-yellow-400 text-white",
+            )}
+            title="Toggle debug panel"
+          >
+            <Settings className="w-5 h-5" />
+          </Button>
+        )}
+        <Button
+          onClick={onEndTurn}
+          disabled={!canUseActions}
+          className={cn(
+            "w-12 h-12 border-2 transition-all duration-200",
+            canUseActions
+              ? "bg-orange-600 hover:bg-orange-700 border-orange-400 text-white"
+              : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
+          )}
+          title="End Turn"
+        >
+          ⏰
+        </Button>
+        <Button
+          onClick={onFlee}
+          disabled={!canUseActions}
+          className={cn(
+            "w-12 h-12 border-2 transition-all duration-200",
+            canUseActions
+              ? "bg-red-600 hover:bg-red-700 border-red-400 text-white"
+              : "bg-gray-500 border-gray-400 text-gray-300 cursor-not-allowed",
+          )}
+          title="Flee from encounter"
+        >
+          🏃
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/test/ActionPanel.test.tsx
+++ b/client/src/test/ActionPanel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ActionPanel from '@/components/game/ActionPanel';
+
+const abilities = [
+  { key: 'peaceAura', name: 'Peace Aura', description: 'Calm foes', icon: '🕊️', cost: 1 },
+  { key: 'flee', name: 'Flee', description: 'Run away', icon: '🏃', cost: 2 },
+];
+
+describe('ActionPanel', () => {
+  it('calls onAbilityUse when clicked', () => {
+    const onUse = vi.fn();
+    render(
+      <ActionPanel abilities={abilities} actionPoints={2} canUseActions={true} onAbilityUse={onUse} />
+    );
+    fireEvent.click(screen.getByTitle(/Peace Aura/));
+    expect(onUse).toHaveBeenCalledWith('peaceAura');
+  });
+
+  it('disables abilities without enough points', () => {
+    render(
+      <ActionPanel abilities={abilities} actionPoints={1} canUseActions={true} onAbilityUse={() => {}} />
+    );
+    const fleeBtn = screen.getByTitle(/Flee/);
+    expect(fleeBtn).toBeDisabled();
+  });
+});

--- a/client/src/test/DebugPanel.test.tsx
+++ b/client/src/test/DebugPanel.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DebugPanel from '@/components/game/DebugPanel';
+
+const baseProps = {
+  visible: true,
+  debugState: { autoTurn: true },
+  onToggleAutoTurn: vi.fn(),
+  onNPCAction: vi.fn(),
+};
+
+describe('DebugPanel', () => {
+  it('does not render when not visible', () => {
+    const { container } = render(<DebugPanel {...baseProps} visible={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('toggles auto turn', () => {
+    render(<DebugPanel {...baseProps} />);
+    fireEvent.click(screen.getByTitle('Toggle automatic NPC turns'));
+    expect(baseProps.onToggleAutoTurn).toHaveBeenCalled();
+  });
+
+  it('shows manual actions when autoTurn is off', () => {
+    render(<DebugPanel {...baseProps} debugState={{ autoTurn: false }} />);
+    fireEvent.click(screen.getByTitle('Gareth Attack'));
+    expect(baseProps.onNPCAction).toHaveBeenCalledWith('npc1', 'attack');
+  });
+});

--- a/client/src/test/StatusBar.test.tsx
+++ b/client/src/test/StatusBar.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StatusBar from '@/components/game/StatusBar';
+
+describe('StatusBar', () => {
+  const defaultProps = {
+    targetingMode: false,
+    canUseActions: true,
+    combatLogMode: 'hidden' as const,
+    showDebugPanel: false,
+    onToggleCombatLog: vi.fn(),
+    onToggleDebug: vi.fn(),
+    onEndTurn: vi.fn(),
+    onFlee: vi.fn(),
+    onOpenInventory: vi.fn(),
+  };
+
+  it('shows status text based on targetingMode', () => {
+    const { rerender } = render(<StatusBar {...defaultProps} />);
+    expect(screen.getByText('✋ READY')).toBeInTheDocument();
+    rerender(<StatusBar {...defaultProps} targetingMode={true} />);
+    expect(screen.getByText('🎯 TARGETING')).toBeInTheDocument();
+  });
+
+  it('calls handlers on button clicks', () => {
+    render(<StatusBar {...defaultProps} />);
+    fireEvent.click(screen.getByTitle('Combat Log: hidden'));
+    fireEvent.click(screen.getByTitle('End Turn'));
+    fireEvent.click(screen.getByTitle('Flee from encounter'));
+    expect(defaultProps.onToggleCombatLog).toHaveBeenCalled();
+    expect(defaultProps.onEndTurn).toHaveBeenCalled();
+    expect(defaultProps.onFlee).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- split ability grid into **ActionPanel** component
- extract status bar to new **StatusBar** component
- move debug controls into **DebugPanel**
- add unit tests for new components to ensure behavior

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_6848a63698208324b6b4aab739f2231e