### PR TITLE
Fix weather effects not applied in battle

### DIFF
--- a/client/src/components/game/GameBoard.tsx
+++ b/client/src/components/game/GameBoard.tsx
@@ -28,6 +28,7 @@ import {
 import {
   getEnvironmentalEffectById,
 } from "@/lib/environmentLoader";
+import { getGlobalMapState } from "@/lib/mapState";
 
 export default function GameBoard() {
   const {
@@ -82,19 +83,26 @@ export default function GameBoard() {
     // Apply color palette for current time phase
     applyPhaseColorPalette(timeState.currentPhase);
 
-    // Add time-based environmental effect
+    const mapState = getGlobalMapState();
+    const weatherEffect = mapState.activeWeatherEffect || null;
+
+    // Add time-based environmental effect along with weather effect if present
     const timeEffect = getTimeBasedEnvironmentalEffect(timeState.currentPhase);
-    setActiveEnvironmentalEffects([timeEffect.id]);
+    setActiveEnvironmentalEffects(
+      weatherEffect ? [timeEffect.id, weatherEffect] : [timeEffect.id]
+    );
 
     const unsubscribe = globalTimeManager.subscribe((newTimeState) => {
       setCurrentTimePhase(newTimeState.currentPhase);
       applyPhaseColorPalette(newTimeState.currentPhase);
 
-      // Update time-based environmental effect
+      // Update time-based environmental effect while keeping weather effect
       const newTimeEffect = getTimeBasedEnvironmentalEffect(
         newTimeState.currentPhase,
       );
-      setActiveEnvironmentalEffects([newTimeEffect.id]);
+      setActiveEnvironmentalEffects(
+        weatherEffect ? [newTimeEffect.id, weatherEffect] : [newTimeEffect.id]
+      );
     });
 
     return unsubscribe;

--- a/client/src/hooks/useMapState.ts
+++ b/client/src/hooks/useMapState.ts
@@ -18,6 +18,7 @@ interface MapState {
   currentZone: string;
   turnCounter: number;
   activeEncounterZone: string | null;
+  activeWeatherEffect: string | null;
   currentTimePhase: TimePhase;
 }
 
@@ -28,6 +29,7 @@ const initialMapState: MapState = {
   currentZone: "grove",
   turnCounter: 1,
   activeEncounterZone: null,
+  activeWeatherEffect: null,
   currentTimePhase: 'day1' as TimePhase
 };
 
@@ -95,10 +97,11 @@ export function useMapState() {
     }));
   }, []);
 
-  const startEncounter = useCallback((zoneId: string) => {
+  const startEncounter = useCallback((zoneId: string, weatherEffect: string | null) => {
     setMapState(prev => ({
       ...prev,
-      activeEncounterZone: zoneId
+      activeEncounterZone: zoneId,
+      activeWeatherEffect: weatherEffect
     }));
   }, []);
 
@@ -228,6 +231,7 @@ export function useMapState() {
     currentZone: mapState.currentZone,
     turnCounter: mapState.turnCounter,
     activeEncounterZone: mapState.activeEncounterZone,
+    activeWeatherEffect: mapState.activeWeatherEffect,
     currentTimePhase: mapState.currentTimePhase,
     setCurrentZone,
     startEncounter,

--- a/client/src/lib/mapState.ts
+++ b/client/src/lib/mapState.ts
@@ -2,11 +2,13 @@
 let globalMapState: {
   resolveEncounter?: (zoneId: string, success: boolean) => void;
   currentEncounterZone?: string;
+  activeWeatherEffect?: string | null;
 } = {};
 
-export function setGlobalMapState(state: { 
+export function setGlobalMapState(state: {
   resolveEncounter: (zoneId: string, success: boolean) => void;
   currentEncounterZone?: string;
+  activeWeatherEffect?: string | null;
 }) {
   globalMapState = state;
 }
@@ -21,4 +23,12 @@ export function setCurrentEncounterZone(zoneId: string) {
 
 export function getCurrentEncounterZone(): string | undefined {
   return globalMapState.currentEncounterZone;
+}
+
+export function setActiveWeatherEffect(effect: string | null) {
+  globalMapState.activeWeatherEffect = effect;
+}
+
+export function getActiveWeatherEffect(): string | null | undefined {
+  return globalMapState.activeWeatherEffect;
 }

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -28,6 +28,7 @@ export default function Map() {
     currentZone,
     turnCounter,
     activeEncounterZone,
+    activeWeatherEffect,
     currentTimePhase,
     setCurrentZone,
     nextTurn,
@@ -67,11 +68,12 @@ export default function Map() {
 
   // Set global map state for encounter resolution
   useEffect(() => {
-    setGlobalMapState({ 
+    setGlobalMapState({
       resolveEncounter,
-      currentEncounterZone: activeEncounterZone || undefined
+      currentEncounterZone: activeEncounterZone || undefined,
+      activeWeatherEffect
     });
-  }, [resolveEncounter, activeEncounterZone]);
+  }, [resolveEncounter, activeEncounterZone, activeWeatherEffect]);
 
   const handleZoneClick = useCallback((zoneId: string) => {
     // Handle debug resolution modes
@@ -92,12 +94,14 @@ export default function Map() {
     
     // If zone has active encounter, launch battle
     if (zone.hasEncounter) {
-      startEncounter(zoneId);
+      const weatherEffect = globalWeatherManager.getActiveEnvironmentalEffect();
+      startEncounter(zoneId, weatherEffect);
       logEncounterStart(turnCounter, zoneId, zone.name);
       // Store the encounter zone in global state
-      setGlobalMapState({ 
+      setGlobalMapState({
         resolveEncounter,
-        currentEncounterZone: zoneId
+        currentEncounterZone: zoneId,
+        activeWeatherEffect: weatherEffect
       });
       setLocation('/game');
     }

--- a/client/src/test/gameBoard.test.tsx
+++ b/client/src/test/gameBoard.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/lib/characterLoader', () => ({
 import { useGameState } from '@/hooks/useGameState';
 import { useInventory } from '@/hooks/useInventory';
 import { loadNPCData, loadPCData } from '@/lib/characterLoader';
+import { setGlobalMapState } from '@/lib/mapState';
 import GameBoard from '@/components/game/GameBoard';
 
 const npcTemplate = {
@@ -60,6 +61,7 @@ const pcData = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  setGlobalMapState({ resolveEncounter: vi.fn(), currentEncounterZone: 'zone1', activeWeatherEffect: 'rain_boost' });
   (loadNPCData as any).mockResolvedValue([
     { ...npcTemplate, id: 'npc1' },
     { ...npcTemplate, id: 'npc2' },
@@ -128,6 +130,12 @@ describe('GameBoard component', () => {
 
     expect(useItem).toHaveBeenCalledWith('energy_crystal');
     expect(applyItemEffects).toHaveBeenCalledWith(energyCrystal.effects, energyCrystal.name);
+  });
+
+  it('displays active weather effect from map state', async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.getByText(/Loading character data/i));
+    expect(screen.getByText(/RAIN_BOOST/i)).toBeInTheDocument();
   });
 });
 

--- a/client/src/test/mapState.test.ts
+++ b/client/src/test/mapState.test.ts
@@ -22,4 +22,13 @@ describe('mapState', () => {
     expect(getCurrentEncounterZone()).toBe('zone2');
     expect(getGlobalMapState().currentEncounterZone).toBe('zone2');
   });
+
+  it('stores and retrieves activeWeatherEffect', async () => {
+    const mod = await import('../lib/mapState');
+    const { setGlobalMapState, getActiveWeatherEffect, setActiveWeatherEffect } = mod;
+    setGlobalMapState({ resolveEncounter: vi.fn(), activeWeatherEffect: 'rain' });
+    expect(getActiveWeatherEffect()).toBe('rain');
+    setActiveWeatherEffect('mist');
+    expect(getActiveWeatherEffect()).toBe('mist');
+  });
 });


### PR DESCRIPTION
## Summary
- store active weather effect in map state and global map state
- provide accessors for active weather effect
- pass current weather effect when starting an encounter
- display stored weather effect on the GameBoard alongside time effects
- test map state storage and GameBoard weather display

## Testing
- `npm run tests`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6848ba9cfd9083249c1a8edc0686c367