### PR TITLE
Fix forest wind skill unlock mismatch

### DIFF
--- a/client/src/lib/historySystem.ts
+++ b/client/src/lib/historySystem.ts
@@ -132,8 +132,8 @@ export class HistoryManager {
     // Check Wind Whisperer skill
     if (!this.history.skillsUnlocked.includes('wind_whisperer')) {
       const hasUsedPeaceAura = encounter.actions.some(action => action.type === 'peace_aura');
-      const hasForestWind = encounter.environmentalEffects.includes('forest_wind') || 
-                           encounter.actions.some(action => action.environmentalEffects?.includes('forest_wind'));
+      const hasForestWind = encounter.environmentalEffects.includes('strong_wind') ||
+                           encounter.actions.some(action => action.environmentalEffects?.includes('strong_wind'));
 
       if (hasUsedPeaceAura && hasForestWind) {
         this.history.skillsUnlocked.push('wind_whisperer');

--- a/data/skills/skill-trees.json
+++ b/data/skills/skill-trees.json
@@ -40,7 +40,7 @@
           },
           "unlockRequirements": {
             "mustUseAbility": "peace_aura",
-            "environmentalEffect": "forest_wind",
+            "environmentalEffect": "strong_wind",
             "description": "Use Peaceful Aura while forest wind environmental effect is active"
           }
         },


### PR DESCRIPTION
## Summary
- fix Wind Whisperer unlock check by using strong_wind id
- align skill data to reference strong_wind environment effect

## Testing
- `npm run tests` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fee9a2688324b40dd15149df1152