### PR TITLE
Add map exit controls to skills screen

### DIFF
--- a/client/src/pages/skills.tsx
+++ b/client/src/pages/skills.tsx
@@ -16,6 +16,7 @@ import {
   Mountain,
   History,
   Target,
+  X,
 } from "lucide-react";
 import { IS_DEBUG } from "@/lib/debug";
 import HistoryDebugModal from "@/components/HistoryDebugModal";
@@ -75,6 +76,17 @@ export default function Skills() {
     });
     return unsubscribe;
   }, []);
+
+  // Allow exiting to the map with the Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setLocation("/map");
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setLocation]);
 
   const handleLearnSkill = useCallback((skillId: string) => {
     globalSkillManager.learnSkill(skillId);
@@ -147,6 +159,17 @@ export default function Skills() {
         onTreeSelect={setSelectedTree}
         skillTrees={skillTrees}
       />
+
+      {/* Exit Button */}
+      <div className="absolute top-4 right-4 z-30">
+        <Button
+          onClick={() => setLocation("/map")}
+          className="bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
+        >
+          <X className="w-4 h-4 mr-2" />
+          Exit to Map
+        </Button>
+      </div>
 
       {/* Tree Title */}
       {currentTree && (

--- a/client/src/test/SkillsPage.test.tsx
+++ b/client/src/test/SkillsPage.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSetLocation = vi.fn();
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['', mockSetLocation],
+}));
+
+vi.mock('../lib/skillTreeLoader', async () => {
+  const actual = await vi.importActual('../lib/skillTreeLoader');
+  const sampleData = {
+    skillTrees: {
+      diplomacy: {
+        category: 'diplomacy',
+        name: 'Diplomacy',
+        description: '',
+        icon: 'D',
+        color: '#fff',
+        nodes: [],
+      },
+    },
+  };
+  return {
+    ...actual,
+    globalSkillManager: {
+      loadSkillTrees: vi.fn().mockResolvedValue(sampleData),
+      getVisibleSkillsForTree: vi.fn().mockReturnValue([]),
+      subscribe: vi.fn().mockReturnValue(() => {}),
+      learnSkill: vi.fn(),
+      debugLearnAllSkills: vi.fn(),
+      debugResetSkills: vi.fn(),
+    },
+  };
+});
+
+import Skills from '../pages/skills';
+
+beforeEach(() => {
+  mockSetLocation.mockClear();
+});
+
+describe('Skills page navigation', () => {
+  it('navigates to map when exit button clicked', async () => {
+    render(<Skills />);
+    const btn = await screen.findByRole('button', { name: /Exit to Map/i });
+    fireEvent.click(btn);
+    expect(mockSetLocation).toHaveBeenCalledWith('/map');
+  });
+
+  it('navigates to map on Escape key', async () => {
+    render(<Skills />);
+    await screen.findByRole('button', { name: /Exit to Map/i });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(mockSetLocation).toHaveBeenCalledWith('/map');
+  });
+});


### PR DESCRIPTION
## Summary
- enable exit from the skills screen via Escape key
- add a top-right `Exit to Map` button on the skills page
- add unit test covering both exit mechanisms

## Testing
- `npm run tests`


------
https://chatgpt.com/codex/tasks/task_e_684908d6741483249398d85bb217ff42