### PR TITLE
Improve targeting mode UI feedback

### DIFF
--- a/client/src/components/game/GameBoard.tsx
+++ b/client/src/components/game/GameBoard.tsx
@@ -8,6 +8,7 @@ import GameOverModal from "./GameOverModal";
 import CombatLog from "./CombatLog";
 import InventoryScreen from "@/components/inventory/InventoryScreen";
 import PlayerUtilsPanel from "./PlayerUtilsPanel";
+import { cn } from "@/lib/utils";
 import TimePhaseEffectsDisplay from "./TimePhaseEffectsDisplay";
 import DebugPanel from "./DebugPanel";
 import abilities from "@/abilities";
@@ -213,10 +214,39 @@ export default function GameBoard() {
     );
   }
 
+  const handleCancelTargeting = () => {
+    clearPendingAbility();
+    setPendingItem(null);
+    setTargetingMode(false);
+  };
+
   return (
-    <div className="relative w-screen h-screen bg-gradient-to-b from-sky-400 via-green-300 to-green-600 overflow-hidden">
+    <div
+      className={cn(
+        "relative w-screen h-screen bg-gradient-to-b from-sky-400 via-green-300 to-green-600 overflow-hidden",
+        gameState.targetingMode && "cursor-crosshair"
+      )}
+    >
       {/* Background Gradient */}
       <div className="absolute inset-0 bg-gradient-to-br from-green-900 via-emerald-800 to-amber-900" />
+
+      {gameState.targetingMode && (
+        <>
+          {/* Dim background overlay */}
+          <div className="absolute inset-0 bg-black opacity-50 pointer-events-none z-10" />
+          {/* Targeting banner */}
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-40 px-4 py-2 bg-yellow-700 bg-opacity-90 text-white font-mono rounded shadow-lg animate-pulse">
+            TARGETING MODE – Select a foe
+          </div>
+          {/* Cancel button */}
+          <button
+            className="absolute bottom-20 left-1/2 -translate-x-1/2 z-40 bg-red-600 hover:bg-red-700 text-white font-mono px-4 py-2 rounded"
+            onClick={handleCancelTargeting}
+          >
+            Cancel
+          </button>
+        </>
+      )}
 
       {/* Turn Indicator */}
       <TurnIndicator

--- a/client/src/components/game/NPCCharacter.tsx
+++ b/client/src/components/game/NPCCharacter.tsx
@@ -57,7 +57,9 @@ export default function NPCCharacter({
         className={cn(
           "w-24 h-32 rounded-lg flex items-center justify-center transition-all duration-200",
           color,
-          targetingMode ? "cursor-crosshair hover:scale-105 hover:brightness-110" : "hover:brightness-110",
+          targetingMode
+            ? "cursor-crosshair hover:scale-105 hover:brightness-110 ring-4 ring-yellow-400 animate-pulse"
+            : "hover:brightness-110",
           getAnimationClass()
         )}
         onClick={onClick}

--- a/client/src/test/gameBoard.test.tsx
+++ b/client/src/test/gameBoard.test.tsx
@@ -125,14 +125,20 @@ function setup() {
 
 describe('GameBoard component', () => {
   it('activates targeting mode on Peace Aura click', async () => {
-    const { container } = setup();
+    const { rerender } = setup();
     await waitForElementToBeRemoved(() => screen.getByText(/Loading character data/i));
     const btn = screen.getByTitle(/Peace Aura/i);
     fireEvent.click(btn);
 
-    const { setTargetingMode, setPendingAbility } = (useGameState as any).mock.results[0].value;
-    expect(setTargetingMode).toHaveBeenCalledWith(true);
-    expect(setPendingAbility).toHaveBeenCalledWith('peaceAura');
+    const state = (useGameState as any).mock.results[0].value;
+    expect(state.setTargetingMode).toHaveBeenCalledWith(true);
+    expect(state.setPendingAbility).toHaveBeenCalledWith('peaceAura');
+
+    // simulate UI state change to show banner
+    state.gameState.targetingMode = true;
+    rerender(<GameBoard />);
+
+    expect(screen.getByText(/TARGETING MODE/i)).toBeInTheDocument();
   });
 
   it('executes Peace Aura on selected NPC', async () => {
@@ -186,6 +192,22 @@ describe('GameBoard component', () => {
 
     expect(ctx.useItem).toHaveBeenCalledWith('smoke_bomb');
     expect(state.applyItemEffects).toHaveBeenCalledWith(smokeBomb.effects, smokeBomb.name, 'npc1');
+    expect(state.setTargetingMode).toHaveBeenCalledWith(false);
+  });
+
+  it('cancels targeting mode via button', async () => {
+    const { rerender } = setup();
+    await waitForElementToBeRemoved(() => screen.getByText(/Loading character data/i));
+    const btn = screen.getByTitle(/Peace Aura/i);
+    fireEvent.click(btn);
+
+    const state = (useGameState as any).mock.results[0].value;
+    state.gameState.targetingMode = true;
+    rerender(<GameBoard />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(state.clearPendingAbility).toHaveBeenCalled();
     expect(state.setTargetingMode).toHaveBeenCalledWith(false);
   });
 


### PR DESCRIPTION
## Summary
- add overlay, banner and cancel button when targeting
- highlight NPCs while selecting a target
- adjust tests to cover new UI behaviours

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_6849092664548324b724f7dd6f46b749