### PR TITLE
Fix duplicate turn increment

### DIFF
--- a/client/src/hooks/useMapState.ts
+++ b/client/src/hooks/useMapState.ts
@@ -202,8 +202,7 @@ export function useMapState() {
 
       return {
         ...prev,
-        zones: newZones,
-        turnCounter: prev.turnCounter + 1
+        zones: newZones
       };
     });
   }, []);

--- a/client/src/test/useMapState.test.ts
+++ b/client/src/test/useMapState.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('../lib/locationLoader', () => ({
+  loadLocationData: vi.fn().mockResolvedValue([])
+}));
+
+vi.mock('@/lib/timeSystem', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/timeSystem')>('@/lib/timeSystem');
+  return {
+    ...actual,
+    applyPhaseColorPalette: vi.fn()
+  };
+});
+
+describe('useMapState nextTurn', () => {
+  beforeEach(async () => {
+    const { globalTimeManager } = await import('@/lib/timeSystem');
+    (globalTimeManager as any).state.turnCounter = 1;
+    globalTimeManager.setPhase('day1');
+  });
+
+  it('increments turn counter once', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.nextTurn();
+    });
+
+    expect(result.current.turnCounter).toBe(2);
+  });
+
+  it('multiple calls advance sequentially', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.nextTurn();
+    });
+    act(() => {
+      result.current.nextTurn();
+    });
+
+    expect(result.current.turnCounter).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `nextTurn` to stop incrementing turn twice
- add unit test for `nextTurn`

## Testing
- `npm run tests`


------
https://chatgpt.com/codex/tasks/task_e_68490836b5c083249eaa034e405cf1a0