### PR TITLE
Implement comprehensive map event logging

### DIFF
--- a/client/src/components/map/MapDebugPanel.tsx
+++ b/client/src/components/map/MapDebugPanel.tsx
@@ -14,6 +14,7 @@ interface MapDebugPanelProps {
   weatherState: any;
   turnCounter: number;
   getEventLog: () => string[];
+  logWeatherChange: (turn: number, details: string) => void;
 }
 
 export default function MapDebugPanel({
@@ -26,7 +27,8 @@ export default function MapDebugPanel({
   currentTimePhase,
   weatherState,
   turnCounter,
-  getEventLog
+  getEventLog,
+  logWeatherChange
 }: MapDebugPanelProps) {
   return (
     <div className="absolute top-4 left-4 z-40">
@@ -113,31 +115,46 @@ export default function MapDebugPanel({
               <div className="space-y-2">
                 <div className="flex gap-1 flex-wrap">
                   <Button
-                    onClick={() => globalWeatherManager.debugTriggerWeather('gentle_rain', turnCounter)}
+                    onClick={() => {
+                      globalWeatherManager.debugTriggerWeather('gentle_rain', turnCounter);
+                      logWeatherChange(turnCounter, 'Weather: Gentle Rain');
+                    }}
                     className="text-xs px-2 py-1 bg-blue-600 hover:bg-blue-700"
                   >
                     🌧️ Rain
                   </Button>
                   <Button
-                    onClick={() => globalWeatherManager.debugTriggerWeather('morning_mist', turnCounter)}
+                    onClick={() => {
+                      globalWeatherManager.debugTriggerWeather('morning_mist', turnCounter);
+                      logWeatherChange(turnCounter, 'Weather: Morning Mist');
+                    }}
                     className="text-xs px-2 py-1 bg-gray-600 hover:bg-gray-700"
                   >
                     🌫️ Mist
                   </Button>
                   <Button
-                    onClick={() => globalWeatherManager.debugTriggerWeather('forest_wind', turnCounter)}
+                    onClick={() => {
+                      globalWeatherManager.debugTriggerWeather('forest_wind', turnCounter);
+                      logWeatherChange(turnCounter, 'Weather: Forest Wind');
+                    }}
                     className="text-xs px-2 py-1 bg-green-600 hover:bg-green-700"
                   >
                     💨 Wind
                   </Button>
                   <Button
-                    onClick={() => globalWeatherManager.debugTriggerWeather('sunbeam_clearing', turnCounter)}
+                    onClick={() => {
+                      globalWeatherManager.debugTriggerWeather('sunbeam_clearing', turnCounter);
+                      logWeatherChange(turnCounter, 'Weather: Sunbeam Clearing');
+                    }}
                     className="text-xs px-2 py-1 bg-yellow-600 hover:bg-yellow-700"
                   >
                     ☀️ Sun
                   </Button>
                   <Button
-                    onClick={() => globalWeatherManager.debugClearWeather(turnCounter)}
+                    onClick={() => {
+                      globalWeatherManager.debugClearWeather(turnCounter);
+                      logWeatherChange(turnCounter, 'Weather cleared');
+                    }}
                     className="text-xs px-2 py-1 bg-red-600 hover:bg-red-700"
                   >
                     Clear

--- a/client/src/lib/MapEventManager.ts
+++ b/client/src/lib/MapEventManager.ts
@@ -1,0 +1,34 @@
+export class MapEventManager {
+  private events: import('./events').MapEvent[] = [];
+  private listeners: Array<(events: import('./events').MapEvent[]) => void> = [];
+
+  addEvent(event: import('./events').MapEvent): void {
+    this.events.push(event);
+    this.notify();
+  }
+
+  getEvents(): import('./events').MapEvent[] {
+    return [...this.events];
+  }
+
+  subscribe(listener: (events: import('./events').MapEvent[]) => void): () => void {
+    this.listeners.push(listener);
+    listener(this.getEvents());
+    return () => {
+      const idx = this.listeners.indexOf(listener);
+      if (idx > -1) this.listeners.splice(idx, 1);
+    };
+  }
+
+  clear(): void {
+    this.events = [];
+    this.notify();
+  }
+
+  private notify() {
+    const events = this.getEvents();
+    this.listeners.forEach(l => l(events));
+  }
+}
+
+export const globalMapEventManager = new MapEventManager();

--- a/client/src/lib/events.ts
+++ b/client/src/lib/events.ts
@@ -18,7 +18,14 @@ export interface MapEvent {
   id: string;
   timestamp: number;
   turn: number;
-  type: 'turn_advance' | 'encounter_start' | 'encounter_complete' | 'zone_change' | 'travel';
+  type:
+    | 'turn_advance'
+    | 'encounter_start'
+    | 'encounter_complete'
+    | 'encounter_generated'
+    | 'zone_change'
+    | 'travel'
+    | 'weather_change';
   zoneId?: string;
   zoneName?: string;
   success?: boolean;
@@ -82,10 +89,14 @@ export function formatMapEventForLog(event: MapEvent): string {
       return `Encounter started in ${event.zoneName}`;
     case 'encounter_complete':
       return `Encounter ${event.success ? 'successful' : 'failed'} in ${event.zoneName}`;
+    case 'encounter_generated':
+      return `Encounter spawned in ${event.zoneName}`;
     case 'zone_change':
       return `Moved to ${event.zoneName}`;
     case 'travel':
       return event.details || 'Travel action';
+    case 'weather_change':
+      return event.details || 'Weather changed';
     default:
       return event.details || 'Unknown event';
   }

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -41,7 +41,9 @@ export default function Map() {
     logTurnAdvance,
     logEncounterStart,
     logEncounterComplete,
+    logEncounterGenerated,
     logZoneChange,
+    logWeatherChange,
     getEventLog
   } = useMapEvents();
 
@@ -137,18 +139,14 @@ export default function Map() {
     // Log weather event if weather changed
     if (weatherChanged) {
       const activeWeather = globalWeatherManager.getWeatherState().activeWeather;
-      const weatherEvent = {
-        id: `weather-${Date.now()}`,
-        timestamp: Date.now(),
-        turn: newTurn,
-        type: 'travel' as const,
-        details: activeWeather 
+      logWeatherChange(
+        newTurn,
+        activeWeather
           ? `Weather: ${activeWeather.effect.name} (${activeWeather.remainingTurns} turns)`
           : 'Weather cleared'
-      };
-      addMapEvent(weatherEvent);
+      );
     }
-  }, [nextTurn, turnCounter, logTurnAdvance, currentTimePhase, addMapEvent]);
+  }, [nextTurn, turnCounter, logTurnAdvance, currentTimePhase, addMapEvent, logWeatherChange]);
 
   const handleNarrativeStart = useCallback(async (scriptId: string) => {
     const script = await loadNarrativeScript(scriptId);
@@ -200,6 +198,7 @@ export default function Map() {
           weatherState={weatherState}
           turnCounter={turnCounter}
           getEventLog={getEventLog}
+          logWeatherChange={logWeatherChange}
         />
       )}
       

--- a/client/src/test/events.test.ts
+++ b/client/src/test/events.test.ts
@@ -115,6 +115,18 @@ describe('formatMapEventForLog', () => {
     expect(formatMapEventForLog(event)).toBe('Encounter successful in Cave');
   });
 
+  it('formats encounter_generated events', () => {
+    const event: MapEvent = {
+      id: '12',
+      timestamp: 0,
+      turn: 12,
+      type: 'encounter_generated',
+      zoneId: 'zone4',
+      zoneName: 'Valley'
+    };
+    expect(formatMapEventForLog(event)).toBe('Encounter spawned in Valley');
+  });
+
   it('formats zone_change events', () => {
     const event: MapEvent = {
       id: '10',
@@ -136,5 +148,16 @@ describe('formatMapEventForLog', () => {
       details: 'Travelling'
     };
     expect(formatMapEventForLog(event)).toBe('Travelling');
+  });
+
+  it('formats weather_change events', () => {
+    const event: MapEvent = {
+      id: '13',
+      timestamp: 0,
+      turn: 13,
+      type: 'weather_change',
+      details: 'Weather: Rain'
+    };
+    expect(formatMapEventForLog(event)).toBe('Weather: Rain');
   });
 });

--- a/client/src/test/mapComponents.test.tsx
+++ b/client/src/test/mapComponents.test.tsx
@@ -41,6 +41,7 @@ describe('MapDebugPanel', () => {
         weatherState={null}
         turnCounter={1}
         getEventLog={() => []}
+        logWeatherChange={() => {}}
       />
     );
 
@@ -73,6 +74,7 @@ describe('MapDebugPanel', () => {
         weatherState={null}
         turnCounter={1}
         getEventLog={() => []}
+        logWeatherChange={() => {}}
       />
     );
 

--- a/client/src/test/mapEventManager.test.ts
+++ b/client/src/test/mapEventManager.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MapEventManager } from '../lib/MapEventManager';
+import { createMapEvent } from '../lib/events';
+
+describe('MapEventManager', () => {
+  let manager: MapEventManager;
+  beforeEach(() => {
+    manager = new MapEventManager();
+  });
+
+  it('stores and notifies events', () => {
+    const events: any[] = [];
+    manager.subscribe(e => events.push(...e));
+    const ev = createMapEvent(1, 'turn_advance');
+    manager.addEvent(ev);
+    expect(events[events.length - 1]).toEqual(ev);
+    expect(manager.getEvents()).toHaveLength(1);
+  });
+});

--- a/client/src/test/useMapEvents.test.ts
+++ b/client/src/test/useMapEvents.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useMapEvents } from '../hooks/useMapEvents';
+import { globalMapEventManager } from '../lib/MapEventManager';
 
 // Tests for useMapEvents hook
 
 describe('useMapEvents hook', () => {
+  beforeEach(() => {
+    globalMapEventManager.clear();
+  });
   it('appends events and formats log correctly', () => {
     const { result } = renderHook(() => useMapEvents());
 
@@ -13,6 +17,8 @@ describe('useMapEvents hook', () => {
       result.current.logEncounterStart(1, 'zone1', 'Forest');
       result.current.logEncounterComplete(1, 'zone1', 'Forest', true);
       result.current.logZoneChange(2, 'zone2', 'Town');
+      result.current.logEncounterGenerated(2, 'zone2', 'Town');
+      result.current.logWeatherChange(2, 'Weather: Rain');
     });
 
     const types = result.current.mapEvents.map(e => e.type);
@@ -21,6 +27,8 @@ describe('useMapEvents hook', () => {
       'encounter_start',
       'encounter_complete',
       'zone_change',
+      'encounter_generated',
+      'weather_change',
     ]);
 
     expect(result.current.getEventLog()).toEqual([
@@ -28,6 +36,8 @@ describe('useMapEvents hook', () => {
       'Encounter started in Forest',
       'Encounter successful in Forest',
       'Moved to Town',
+      'Encounter spawned in Town',
+      'Weather: Rain',
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- add `MapEventManager` for a global event stream
- support new map event types for weather changes and encounter generation
- persist map events via `MapEventManager` in `useMapEvents`
- log encounter resolution and encounter generation in `useMapState`
- expose weather logging in `MapDebugPanel` and use it in debug controls
- update map page to use new weather logging
- expand unit tests

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_68490b40b3e48324a80161a00ec53bc0