### PR TITLE
Fix history tracking for encounters

### DIFF
--- a/client/src/components/game/GameOverModal.tsx
+++ b/client/src/components/game/GameOverModal.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useLocation } from "wouter";
 import { getGlobalMapState } from "@/lib/mapState";
+import { globalHistoryManager } from "@/lib/historySystem";
 
 interface GameOverModalProps {
   visible: boolean;
@@ -21,6 +22,12 @@ export default function GameOverModal({ visible, title, message, icon, onRestart
     
     // Reset the game state first
     onRestart();
+
+    let result: 'success' | 'failure' | 'fled' = 'failure';
+    if (isSuccess) result = 'success';
+    else if (isFlee) result = 'fled';
+
+    globalHistoryManager.completeEncounter(result);
     
     // Resolve the encounter with the appropriate result
     const mapState = getGlobalMapState();

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -11,9 +11,10 @@ import ForestZone from "@/components/map/ForestZone";
 import TurnCounter from "@/components/map/TurnCounter";
 import MapDebugPanel from "@/components/map/MapDebugPanel";
 import { loadEnvironmentalEffects, EnvironmentalEffect } from "@/lib/environmentLoader";
-import { globalTimeManager, type TimePhase, getTimeBasedGradient } from "@/lib/timeSystem";
+import { globalTimeManager, type TimePhase, getTimeBasedGradient, getTimeBasedEnvironmentalEffect } from "@/lib/timeSystem";
 import { globalWeatherManager, useWeatherState } from "@/lib/weatherSystem";
 import { useMapEvents } from "@/hooks/useMapEvents";
+import { globalHistoryManager } from "@/lib/historySystem";
 
 
 export default function Map() {
@@ -96,6 +97,21 @@ export default function Map() {
     if (zone.hasEncounter) {
       const weatherEffect = globalWeatherManager.getActiveEnvironmentalEffect();
       startEncounter(zoneId, weatherEffect);
+
+      const timeEffect = getTimeBasedEnvironmentalEffect(currentTimePhase);
+      const envEffects = [timeEffect.id];
+      if (zone.environmentEffect) {
+        envEffects.push(zone.environmentEffect);
+      }
+      globalHistoryManager.startEncounter(
+        zoneId,
+        zone.name,
+        turnCounter,
+        envEffects,
+        weatherEffect || undefined,
+        currentTimePhase
+      );
+
       logEncounterStart(turnCounter, zoneId, zone.name);
       // Store the encounter zone in global state
       setGlobalMapState({
@@ -105,7 +121,7 @@ export default function Map() {
       });
       setLocation('/game');
     }
-  }, [currentZone, zones, setCurrentZone, startEncounter, setLocation, resolveEncounter, resolutionMode, logZoneChange, logEncounterStart, turnCounter]);
+  }, [currentZone, zones, setCurrentZone, startEncounter, setLocation, resolveEncounter, resolutionMode, logZoneChange, logEncounterStart, turnCounter, currentTimePhase]);
 
   const handleNextTurn = useCallback(() => {
     const newTurn = turnCounter + 1;

--- a/client/src/test/GameOverModal.test.tsx
+++ b/client/src/test/GameOverModal.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['', vi.fn()],
+}));
+
+const resolveEncounter = vi.fn();
+vi.mock('../lib/mapState', () => ({
+  getGlobalMapState: () => ({
+    resolveEncounter,
+    currentEncounterZone: 'zone1',
+  }),
+}));
+
+import { globalHistoryManager } from '../lib/historySystem';
+import { debugReset } from '../lib/historyDebug';
+import GameOverModal from '../components/game/GameOverModal';
+
+describe('GameOverModal history', () => {
+  beforeEach(() => {
+    debugReset(globalHistoryManager);
+    vi.restoreAllMocks();
+  });
+
+  it('records successful encounters', () => {
+    const onRestart = vi.fn();
+    const spy = vi.spyOn(globalHistoryManager, 'completeEncounter');
+
+    render(
+      <GameOverModal
+        visible
+        title="PEACE ACHIEVED"
+        message="done"
+        icon=""
+        onRestart={onRestart}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/RETURN TO MAP/i));
+    expect(spy).toHaveBeenCalledWith('success');
+    expect(onRestart).toHaveBeenCalled();
+  });
+
+  it('records fled encounters', () => {
+    const onRestart = vi.fn();
+    const spy = vi.spyOn(globalHistoryManager, 'completeEncounter');
+
+    render(
+      <GameOverModal
+        visible
+        title="FLED ENCOUNTER"
+        message="done"
+        icon=""
+        onRestart={onRestart}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/RETURN TO MAP/i));
+    expect(spy).toHaveBeenCalledWith('fled');
+  });
+});

--- a/client/src/test/MapHistory.test.tsx
+++ b/client/src/test/MapHistory.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSetLocation = vi.fn();
+vi.mock('wouter', () => ({
+  useLocation: () => ['', mockSetLocation],
+}));
+
+const startEncounterMock = vi.fn();
+const setCurrentZoneMock = vi.fn();
+const resolveEncounterMock = vi.fn();
+
+vi.mock('../hooks/useMapState', () => ({
+  useMapState: () => ({
+    zones: [
+      {
+        id: 'forest',
+        name: 'Forest',
+        heat: 10,
+        hasEncounter: true,
+        position: { x: 50, y: 50 },
+        icon: '🌲',
+        description: '',
+        environmentEffect: 'mist',
+      },
+    ],
+    currentZone: '',
+    turnCounter: 2,
+    activeEncounterZone: null,
+    activeWeatherEffect: null,
+    currentTimePhase: 'day1',
+    setCurrentZone: setCurrentZoneMock,
+    startEncounter: startEncounterMock,
+    resolveEncounter: resolveEncounterMock,
+    nextTurn: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useMapEvents', () => ({
+  useMapEvents: () => ({
+    addMapEvent: vi.fn(),
+    logTurnAdvance: vi.fn(),
+    logEncounterStart: vi.fn(),
+    logEncounterComplete: vi.fn(),
+    logZoneChange: vi.fn(),
+    getEventLog: vi.fn(() => []),
+  }),
+}));
+
+vi.mock('../lib/environmentLoader', () => ({
+  loadEnvironmentalEffects: vi.fn().mockResolvedValue({ environmentalEffects: {} }),
+}));
+
+vi.mock('@/lib/timeSystem', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/timeSystem')>(
+    '@/lib/timeSystem'
+  );
+  return {
+    ...actual,
+    globalTimeManager: {
+      getState: () => ({ currentPhase: 'day1', phaseIndex: 0, turnCounter: 2 }),
+      subscribe: () => () => {},
+      getCurrentPhaseInfo: () => ({
+        name: 'Early Day',
+        icon: '🌅',
+        effectId: 'daylight',
+        colorPalette: { primary: '', secondary: '', accent: '', background: '' },
+      }),
+      getAllPhases: () => ['day1'],
+      setPhase: vi.fn(),
+      getPhaseInfo: () => ({
+        name: 'Early Day',
+        icon: '🌅',
+        effectId: 'daylight',
+        colorPalette: { primary: '', secondary: '', accent: '', background: '' },
+      }),
+    },
+    getTimeBasedGradient: () => '',
+    getTimeBasedEnvironmentalEffect: () => ({ id: 'daylight' }),
+  };
+});
+
+vi.mock('@/lib/weatherSystem', () => ({
+  globalWeatherManager: {
+    loadWeatherData: vi.fn(),
+    getActiveEnvironmentalEffect: vi.fn(() => 'rain'),
+    checkForWeatherTrigger: vi.fn(),
+    getWeatherState: vi.fn(() => ({ activeWeather: null })),
+    subscribe: vi.fn(() => () => {}),
+  },
+  useWeatherState: () => null,
+}));
+
+import { globalHistoryManager } from '../lib/historySystem';
+import { debugReset } from '../lib/historyDebug';
+import Map from '../pages/map';
+
+describe('Map encounter history', () => {
+  beforeEach(() => {
+    debugReset(globalHistoryManager);
+    vi.restoreAllMocks();
+    startEncounterMock.mockClear();
+    setCurrentZoneMock.mockClear();
+    resolveEncounterMock.mockClear();
+    mockSetLocation.mockClear();
+  });
+
+  it('records encounter start when zone clicked', async () => {
+    const spy = vi.spyOn(globalHistoryManager, 'startEncounter');
+    render(<Map />);
+
+    fireEvent.click(screen.getByText('Forest'));
+
+    expect(spy).toHaveBeenCalled();
+    const args = spy.mock.calls[0];
+    expect(args[0]).toBe('forest');
+    expect(args[1]).toBe('Forest');
+    expect(args[2]).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- record encounters using `globalHistoryManager` when a zone battle starts
- store encounter results in history when returning from GameOver modal
- add unit tests covering new history tracking logic

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_68490d8a444483248652428ec278f888