### PR TITLE
Add unit tests for map action points

### DIFF
--- a/client/src/hooks/useMapState.ts
+++ b/client/src/hooks/useMapState.ts
@@ -22,6 +22,8 @@ interface MapState {
   activeEncounterZone: string | null;
   activeWeatherEffect: string | null;
   currentTimePhase: TimePhase;
+  actionPoints: number;
+  maxActionPoints: number;
 }
 
 const defaultZones: Zone[] = [];
@@ -32,7 +34,9 @@ const initialMapState: MapState = {
   turnCounter: 1,
   activeEncounterZone: null,
   activeWeatherEffect: null,
-  currentTimePhase: 'day1' as TimePhase
+  currentTimePhase: 'day1' as TimePhase,
+  actionPoints: 1,
+  maxActionPoints: 1
 };
 
 function rollDice(min = 1, max = 6): number {
@@ -99,6 +103,20 @@ export function useMapState() {
     }));
   }, []);
 
+  const spendActionPoint = useCallback((amount: number = 1) => {
+    setMapState(prev => ({
+      ...prev,
+      actionPoints: Math.max(0, prev.actionPoints - amount)
+    }));
+  }, []);
+
+  const restoreActionPoints = useCallback((amount: number = 1) => {
+    setMapState(prev => ({
+      ...prev,
+      actionPoints: Math.min(prev.maxActionPoints, prev.actionPoints + amount)
+    }));
+  }, []);
+
   const startEncounter = useCallback((zoneId: string, weatherEffect: string | null) => {
     setMapState(prev => ({
       ...prev,
@@ -141,7 +159,7 @@ export function useMapState() {
   const nextTurn = useCallback(() => {
     // Advance time phase first
     globalTimeManager.advancePhase();
-    
+
     setMapState(prev => {
       const newZones = prev.zones.map(zone => {
         // Skip if zone already has encounter
@@ -209,7 +227,8 @@ export function useMapState() {
 
       return {
         ...prev,
-        zones: newZones
+        zones: newZones,
+        actionPoints: prev.maxActionPoints
       };
     });
   }, []);
@@ -239,7 +258,11 @@ export function useMapState() {
     activeEncounterZone: mapState.activeEncounterZone,
     activeWeatherEffect: mapState.activeWeatherEffect,
     currentTimePhase: mapState.currentTimePhase,
+    actionPoints: mapState.actionPoints,
+    maxActionPoints: mapState.maxActionPoints,
     setCurrentZone,
+    spendActionPoint,
+    restoreActionPoints,
     startEncounter,
     resolveEncounter,
     nextTurn,

--- a/client/src/hooks/useMapState.ts
+++ b/client/src/hooks/useMapState.ts
@@ -11,7 +11,7 @@ export interface Zone {
   heat: number;
   hasEncounter: boolean;
   position: { x: number; y: number };
-  icon: string;
+  maxActionPoints: 1,
   description: string;
   environmentEffect?: string;
 }

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -30,7 +30,11 @@ export default function Map() {
     activeEncounterZone,
     activeWeatherEffect,
     currentTimePhase,
+    actionPoints,
+    maxActionPoints,
     setCurrentZone,
+    spendActionPoint,
+    restoreActionPoints,
     nextTurn,
     startEncounter,
     resolveEncounter
@@ -86,12 +90,15 @@ export default function Map() {
       return;
     }
 
+    if (actionPoints <= 0) return;
+
     if (currentZone === zoneId) return; // Re-clicking current zone does nothing
     
     const zone = zones.find(z => z.id === zoneId);
     if (!zone) return;
 
     setCurrentZone(zoneId);
+    spendActionPoint();
     logZoneChange(turnCounter, zoneId, zone.name);
     
     // If zone has active encounter, launch battle
@@ -107,7 +114,7 @@ export default function Map() {
       });
       setLocation('/game');
     }
-  }, [currentZone, zones, setCurrentZone, startEncounter, setLocation, resolveEncounter, resolutionMode, logZoneChange, logEncounterStart, turnCounter]);
+  }, [currentZone, zones, setCurrentZone, startEncounter, setLocation, resolveEncounter, resolutionMode, logZoneChange, logEncounterStart, turnCounter, actionPoints, spendActionPoint]);
 
   const handleNextTurn = useCallback(() => {
     const newTurn = turnCounter + 1;

--- a/client/src/test/useMapState.test.ts
+++ b/client/src/test/useMapState.test.ts
@@ -51,3 +51,65 @@ describe('useMapState nextTurn', () => {
     expect(result.current.turnCounter).toBe(3);
   });
 });
+
+describe('useMapState action points', () => {
+  beforeEach(async () => {
+    const { globalTimeManager } = await import('@/lib/timeSystem');
+    (globalTimeManager as any).state.turnCounter = 1;
+    globalTimeManager.setPhase('day1');
+  });
+
+  it('initializes action points at max', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.actionPoints).toBe(1);
+    expect(result.current.maxActionPoints).toBe(1);
+  });
+
+  it('spend and restore modify points within bounds', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.spendActionPoint();
+    });
+    expect(result.current.actionPoints).toBe(0);
+
+    act(() => {
+      result.current.spendActionPoint();
+    });
+    expect(result.current.actionPoints).toBe(0);
+
+    act(() => {
+      result.current.restoreActionPoints();
+    });
+    expect(result.current.actionPoints).toBe(1);
+  });
+
+  it('nextTurn resets action points to max', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.spendActionPoint();
+    });
+    expect(result.current.actionPoints).toBe(0);
+
+    act(() => {
+      result.current.nextTurn();
+    });
+
+    expect(result.current.actionPoints).toBe(result.current.maxActionPoints);
+  });
+});


### PR DESCRIPTION
## Summary
- track action points in `useMapState`
- expose AP controls on map page
- test spending, restoring, and resetting AP between turns

## Testing
- `npm run tests`


------
https://chatgpt.com/codex/tasks/task_e_684912196ff88324a34d81eea75ca0d8