### PR TITLE
Add map actions loader tests

### DIFF
--- a/client/src/hooks/useMapState.ts
+++ b/client/src/hooks/useMapState.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { loadLocationData } from "../lib/locationLoader";
+import { loadMapActions, type MapAction } from "@/lib/mapActionLoader";
 import { globalTimeManager, type TimePhase, applyPhaseColorPalette } from "@/lib/timeSystem";
 import { globalMapEventManager } from "@/lib/MapEventManager";
 import { createMapEvent } from "@/lib/events";
@@ -22,6 +23,7 @@ interface MapState {
   activeEncounterZone: string | null;
   activeWeatherEffect: string | null;
   currentTimePhase: TimePhase;
+  mapActions: MapAction[];
 }
 
 const defaultZones: Zone[] = [];
@@ -32,7 +34,8 @@ const initialMapState: MapState = {
   turnCounter: 1,
   activeEncounterZone: null,
   activeWeatherEffect: null,
-  currentTimePhase: 'day1' as TimePhase
+  currentTimePhase: 'day1' as TimePhase,
+  mapActions: []
 };
 
 function rollDice(min = 1, max = 6): number {
@@ -65,6 +68,22 @@ export function useMapState() {
       }
     };
     loadZones();
+  }, []);
+
+  // Load map actions on initialization
+  useEffect(() => {
+    const loadActions = async () => {
+      try {
+        const actions = await loadMapActions();
+        setMapState(prev => ({
+          ...prev,
+          mapActions: actions
+        }));
+      } catch (error) {
+        console.error('Failed to load map actions:', error);
+      }
+    };
+    loadActions();
   }, []);
 
   // Initialize time system and sync with map state
@@ -239,6 +258,7 @@ export function useMapState() {
     activeEncounterZone: mapState.activeEncounterZone,
     activeWeatherEffect: mapState.activeWeatherEffect,
     currentTimePhase: mapState.currentTimePhase,
+    mapActions: mapState.mapActions,
     setCurrentZone,
     startEncounter,
     resolveEncounter,

--- a/client/src/lib/mapActionLoader.ts
+++ b/client/src/lib/mapActionLoader.ts
@@ -1,0 +1,14 @@
+import type { PCAbility } from './characterLoader';
+
+export type MapAction = PCAbility;
+
+export async function loadMapActions(): Promise<MapAction[]> {
+  try {
+    const response = await fetch('/data/map-actions.json');
+    if (!response.ok) throw new Error('Failed to load map actions');
+    return await response.json();
+  } catch (error) {
+    console.error('Error loading map actions:', error);
+    return [];
+  }
+}

--- a/client/src/test/useMapState.test.ts
+++ b/client/src/test/useMapState.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
+const loadLocationDataMock = vi.fn().mockResolvedValue([]);
 vi.mock('../lib/locationLoader', () => ({
-  loadLocationData: vi.fn().mockResolvedValue([])
+  loadLocationData: loadLocationDataMock
+}));
+
+const loadMapActionsMock = vi.fn();
+vi.mock('../lib/mapActionLoader', () => ({
+  loadMapActions: loadMapActionsMock
 }));
 
 vi.mock('@/lib/timeSystem', async () => {
@@ -11,6 +17,35 @@ vi.mock('@/lib/timeSystem', async () => {
     ...actual,
     applyPhaseColorPalette: vi.fn()
   };
+});
+
+describe('useMapState mapActions', () => {
+  beforeEach(async () => {
+    const { globalTimeManager } = await import('@/lib/timeSystem');
+    (globalTimeManager as any).state.turnCounter = 1;
+    globalTimeManager.setPhase('day1');
+    loadMapActionsMock.mockResolvedValue([
+      {
+        key: 'travel',
+        name: 'Travel',
+        description: 'Move to a nearby zone',
+        icon: '🧭',
+        cost: 1,
+      },
+    ]);
+  });
+
+  it('loads actions into state', async () => {
+    const { useMapState } = await import('../hooks/useMapState');
+    const { result } = renderHook(() => useMapState());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.mapActions.length).toBe(1);
+    expect(result.current.mapActions[0].key).toBe('travel');
+  });
 });
 
 describe('useMapState nextTurn', () => {

--- a/data/map-actions.json
+++ b/data/map-actions.json
@@ -1,0 +1,9 @@
+[
+  {
+    "key": "travel",
+    "name": "Travel",
+    "description": "Move to a nearby zone using action points",
+    "icon": "🧭",
+    "cost": 1
+  }
+]


### PR DESCRIPTION
## Summary
- reuse `PCAbility` for new `MapAction` type
- test loading of actions in `useMapState`

## Testing
- `npm run check`
- `npm run tests`


------
https://chatgpt.com/codex/tasks/task_e_6849120a4d148324a8680ecf313ef611