### PR TITLE
Show immobilize status and auto-skip snared NPC turns

### DIFF
--- a/client/src/components/game/GameBoard.tsx
+++ b/client/src/components/game/GameBoard.tsx
@@ -104,7 +104,7 @@ export default function GameBoard() {
       weatherEffect ? [timeEffect.id, weatherEffect] : [timeEffect.id],
     );
 
-    const unsubscribe = globalTimeManager.subscribe((newTimeState) => {
+    const unsubscribe = globalTimeManager.subscribe(newTimeState => {
       setCurrentTimePhase(newTimeState.currentPhase);
       applyPhaseColorPalette(newTimeState.currentPhase);
 
@@ -169,7 +169,7 @@ export default function GameBoard() {
 
   // Debug functions
   const toggleAutoTurn = () => {
-    setDebugState((prev) => {
+    setDebugState(prev => {
       const newAutoTurn = !prev.autoTurn;
       setAutoTurnEnabled(newAutoTurn);
       return { ...prev, autoTurn: newAutoTurn };
@@ -230,7 +230,7 @@ export default function GameBoard() {
     <div
       className={cn(
         "relative w-screen h-screen bg-gradient-to-b from-sky-400 via-green-300 to-green-600 overflow-hidden",
-        gameState.targetingMode && "cursor-crosshair"
+        gameState.targetingMode && "cursor-crosshair",
       )}
     >
       {/* Background Gradient */}
@@ -270,11 +270,13 @@ export default function GameBoard() {
         name={gameState.npc1.name}
         npc={gameState.npc1.stats}
         position="left"
+        immobilized={gameState.npc1.immobilized}
       />
       <NPCStatsDisplay
         name={gameState.npc2.name}
         npc={gameState.npc2.stats}
         position="right"
+        immobilized={gameState.npc2.immobilized}
       />
 
       {/* NPC Characters */}
@@ -288,6 +290,7 @@ export default function GameBoard() {
           onClick={() => handleNPCClick("npc1")}
           icon={gameState.npc1.icon}
           color={gameState.npc1.color}
+          immobilized={gameState.npc1.immobilized}
         />
       </div>
 
@@ -301,6 +304,7 @@ export default function GameBoard() {
           onClick={() => handleNPCClick("npc2")}
           icon={gameState.npc2.icon}
           color={gameState.npc2.color}
+          immobilized={gameState.npc2.immobilized}
         />
       </div>
 

--- a/client/src/components/game/NPCCharacter.tsx
+++ b/client/src/components/game/NPCCharacter.tsx
@@ -15,86 +15,103 @@ interface NPCCharacterProps {
   id: string;
   name: string;
   npc: NPCStats;
-  position: 'left' | 'right';
+  position: "left" | "right";
   targetingMode: boolean;
   onClick: () => void;
   icon: string;
   color: string;
+  immobilized?: number;
   isAnimating?: boolean;
-  animationType?: 'attack' | 'hit' | 'heal';
+  animationType?: "attack" | "hit" | "heal";
 }
 
-export default function NPCCharacter({ 
-  id, 
+export default function NPCCharacter({
+  id,
   name,
-  npc, 
-  position, 
-  targetingMode, 
-  onClick, 
-  icon, 
+  npc,
+  position,
+  targetingMode,
+  onClick,
+  icon,
   color,
+  immobilized = 0,
   isAnimating = false,
-  animationType = 'attack'
+  animationType = "attack",
 }: NPCCharacterProps) {
   const getAnimationClass = () => {
-    if (!isAnimating) return '';
+    if (!isAnimating) return "";
     switch (animationType) {
-      case 'attack':
-        return position === 'left' ? 'animate-attack-right' : 'animate-attack-left';
-      case 'hit':
-        return 'animate-hit-shake';
-      case 'heal':
-        return 'animate-heal-glow';
+      case "attack":
+        return position === "left"
+          ? "animate-attack-right"
+          : "animate-attack-left";
+      case "hit":
+        return "animate-hit-shake";
+      case "heal":
+        return "animate-heal-glow";
       default:
-        return '';
+        return "";
     }
   };
 
   return (
     <div className="relative">
       {/* NPC Character - Only the sprite, no stats */}
-      <div 
+      <div
         className={cn(
           "w-24 h-32 rounded-lg flex items-center justify-center transition-all duration-200",
           color,
           targetingMode
             ? "cursor-crosshair hover:scale-105 hover:brightness-110 ring-4 ring-yellow-400 animate-pulse"
             : "hover:brightness-110",
-          getAnimationClass()
+          getAnimationClass(),
         )}
         onClick={onClick}
       >
         <div className="text-4xl">{icon}</div>
       </div>
+      {immobilized > 0 && (
+        <div
+          className="absolute -top-2 -right-2 bg-green-700 text-white text-xs px-1 rounded flex items-center space-x-1"
+          title="Entangled"
+        >
+          <span>🌿</span>
+          <span>{immobilized}</span>
+        </div>
+      )}
     </div>
   );
 }
 
 // New component for character stats display at top of screen
-export function NPCStatsDisplay({ 
-  name, 
-  npc, 
-  position 
-}: { 
-  name: string; 
-  npc: NPCStats; 
-  position: 'left' | 'right';
+export function NPCStatsDisplay({
+  name,
+  npc,
+  position,
+  immobilized = 0,
+}: {
+  name: string;
+  npc: NPCStats;
+  position: "left" | "right";
+  immobilized?: number;
 }) {
   const healthPercent = (npc.health / npc.maxHealth) * 100;
   const willPercent = (npc.willToFight / npc.maxWill) * 100;
   const awarenessPercent = (npc.awareness / npc.maxAwareness) * 100;
-  
+
   const getAwarenessColor = (awarenessPercent: number) => {
-    if (awarenessPercent < 33) return 'bg-green-500';
-    if (awarenessPercent < 66) return 'bg-yellow-500';
-    return 'bg-red-500';
+    if (awarenessPercent < 33) return "bg-green-500";
+    if (awarenessPercent < 66) return "bg-yellow-500";
+    return "bg-red-500";
   };
 
   return (
-    <div className={cn(
-      "absolute top-4 w-48 z-30",
-      position === 'left' ? 'left-4' : 'right-4'
-    )}>
+    <div
+      className={cn(
+        "absolute top-4 w-48 z-30",
+        position === "left" ? "left-4" : "right-4",
+      )}
+    >
       <div className="bg-gray-900 bg-opacity-90 rounded-lg p-2 border border-gray-600">
         {/* Character Name */}
         <div className="text-center mb-2">
@@ -107,20 +124,23 @@ export function NPCStatsDisplay({
           <div className="bg-gray-700 rounded-full p-1">
             <div className="relative h-2 bg-gray-600 rounded-full overflow-hidden">
               {/* Health bar */}
-              <div 
+              <div
                 className="bar-fill h-full bg-red-500 rounded-full transition-all duration-500 ease-out"
                 style={{ width: `${healthPercent}%` }}
               />
               {/* Armor overlay */}
               {npc.armor > 0 && (
-                <div 
+                <div
                   className="absolute top-0 left-0 h-full bg-gray-400 rounded-full transition-all duration-500 ease-out"
-                  style={{ width: `${Math.min(healthPercent, (npc.armor / npc.maxHealth) * 100)}%` }}
+                  style={{
+                    width: `${Math.min(healthPercent, (npc.armor / npc.maxHealth) * 100)}%`,
+                  }}
                 />
               )}
             </div>
             <div className="text-xs font-mono text-white text-center">
-              {npc.health}/{npc.maxHealth}{npc.armor > 0 ? ` (+${npc.armor})` : ''}
+              {npc.health}/{npc.maxHealth}
+              {npc.armor > 0 ? ` (+${npc.armor})` : ""}
             </div>
           </div>
         </div>
@@ -130,7 +150,7 @@ export function NPCStatsDisplay({
           <div className="text-xs font-mono text-gray-400 mb-1">WILL</div>
           <div className="bg-gray-700 rounded-full p-1">
             <div className="relative h-2 bg-gray-600 rounded-full overflow-hidden">
-              <div 
+              <div
                 className="bar-fill h-full bg-blue-500 rounded-full transition-all duration-500 ease-out"
                 style={{ width: `${willPercent}%` }}
               />
@@ -146,10 +166,10 @@ export function NPCStatsDisplay({
           <div className="text-xs font-mono text-gray-400 mb-1">AWARE</div>
           <div className="bg-gray-700 rounded-full p-1">
             <div className="relative h-2 bg-gray-600 rounded-full overflow-hidden">
-              <div 
+              <div
                 className={cn(
                   "bar-fill h-full rounded-full transition-all duration-500 ease-out",
-                  getAwarenessColor(awarenessPercent)
+                  getAwarenessColor(awarenessPercent),
                 )}
                 style={{ width: `${awarenessPercent}%` }}
               />
@@ -159,6 +179,14 @@ export function NPCStatsDisplay({
             </div>
           </div>
         </div>
+
+        {immobilized > 0 && (
+          <div className="mt-2 text-center">
+            <div className="text-xs font-mono text-green-400">
+              ENTANGLED {immobilized} TURN{immobilized > 1 ? "S" : ""}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/lib/turnManager.ts
+++ b/client/src/lib/turnManager.ts
@@ -51,13 +51,16 @@ export class TurnManager {
 
     if (npc.immobilized && npc.immobilized > 0) {
       this.addLogEntry(`${npc.name} is restrained by vines and cannot act!`);
-      this.setGameState((prev) => {
+      this.setGameState(prev => {
         const newState = { ...prev };
         const n = newState[npcId];
         n.immobilized = (n.immobilized || 1) - 1;
-        return this.advanceTurn(newState);
+        return newState;
       });
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      this.setGameState(prev => this.advanceTurn(prev));
       return;
     }
 
@@ -65,7 +68,7 @@ export class TurnManager {
     const action = executeNPCAction(roll);
 
     // Update game state with NPC action
-    this.setGameState((prev) => {
+    this.setGameState(prev => {
       const newState = { ...prev };
       const npc = newState[npcId];
       const targetId = npcId === "npc1" ? "npc2" : "npc1";
@@ -129,10 +132,10 @@ export class TurnManager {
     });
 
     // Wait for action animation
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Check for game end and advance turn
-    this.setGameState((prev) => {
+    this.setGameState(prev => {
       if (!this.checkGameEnd(prev)) {
         return this.advanceTurn(prev);
       }
@@ -141,7 +144,7 @@ export class TurnManager {
   }
 
   async rollDiceWithAnimation(): Promise<number> {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       this.setDiceState({
         visible: true,
         rolling: true,
@@ -151,7 +154,7 @@ export class TurnManager {
 
       setTimeout(() => {
         const result = rollDice(1, 6);
-        this.setDiceState((prev) => ({
+        this.setDiceState(prev => ({
           ...prev,
           rolling: false,
           result,
@@ -159,7 +162,7 @@ export class TurnManager {
         }));
 
         setTimeout(() => {
-          this.setDiceState((prev) => ({ ...prev, visible: false }));
+          this.setDiceState(prev => ({ ...prev, visible: false }));
           resolve(result);
         }, 1000);
       }, 1000);
@@ -187,7 +190,7 @@ export class TurnManager {
   }
 
   manualAdvanceTurn(): void {
-    this.setGameState((prev) => {
+    this.setGameState(prev => {
       if (!this.checkGameEnd(prev)) {
         return this.advanceTurn(prev);
       }
@@ -220,7 +223,7 @@ export class TurnManager {
       };
 
       // Update game state with forced NPC action
-      this.setGameState((prev) => {
+      this.setGameState(prev => {
         const newState = { ...prev };
         const npc = newState[npcId];
         const targetId = npcId === "npc1" ? "npc2" : "npc1";
@@ -249,7 +252,7 @@ export class TurnManager {
 
       // Check for game end after action
       setTimeout(() => {
-        this.setGameState((prev) => {
+        this.setGameState(prev => {
           this.checkGameEnd(prev);
           return prev;
         });
@@ -257,7 +260,7 @@ export class TurnManager {
 
       // Advance turn after action
       setTimeout(() => {
-        this.setGameState((prev) => this.advanceTurn(prev));
+        this.setGameState(prev => this.advanceTurn(prev));
       }, 1500);
     } finally {
       this.isExecuting = false;

--- a/client/src/test/turnManager.test.ts
+++ b/client/src/test/turnManager.test.ts
@@ -1,18 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
-import { TurnManager } from '../lib/turnManager';
-import type { GameState, DiceState } from '../lib/gameLogic';
+import { describe, it, expect, vi } from "vitest";
+import { TurnManager } from "../lib/turnManager";
+import type { GameState, DiceState } from "../lib/gameLogic";
 
-function createBaseState(currentTurn: 'npc1' | 'npc2' | 'druid', turnCounter = 1): GameState {
+function createBaseState(
+  currentTurn: "npc1" | "npc2" | "druid",
+  turnCounter = 1,
+): GameState {
   return {
     currentTurn,
     turnCounter,
     npc1: {
-      id: 'npc1',
-      name: 'NPC 1',
-      icon: '',
-      color: '',
-      description: '',
-      position: 'left',
+      id: "npc1",
+      name: "NPC 1",
+      icon: "",
+      color: "",
+      description: "",
+      position: "left",
       stats: {
         health: 10,
         maxHealth: 10,
@@ -27,12 +30,12 @@ function createBaseState(currentTurn: 'npc1' | 'npc2' | 'druid', turnCounter = 1
       immobilized: 0,
     },
     npc2: {
-      id: 'npc2',
-      name: 'NPC 2',
-      icon: '',
-      color: '',
-      description: '',
-      position: 'right',
+      id: "npc2",
+      name: "NPC 2",
+      icon: "",
+      color: "",
+      description: "",
+      position: "right",
       stats: {
         health: 10,
         maxHealth: 10,
@@ -47,10 +50,10 @@ function createBaseState(currentTurn: 'npc1' | 'npc2' | 'druid', turnCounter = 1
       immobilized: 0,
     },
     druid: {
-      id: 'druid',
-      name: 'Druid',
-      icon: '',
-      color: '',
+      id: "druid",
+      name: "Druid",
+      icon: "",
+      color: "",
       stats: {
         hidden: true,
         actionPoints: 3,
@@ -65,30 +68,25 @@ function createBaseState(currentTurn: 'npc1' | 'npc2' | 'druid', turnCounter = 1
   };
 }
 
-describe('TurnManager', () => {
-  it('advanceTurn cycles turns correctly', () => {
-    const manager = new TurnManager(
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-      vi.fn(),
-    );
+describe("TurnManager", () => {
+  it("advanceTurn cycles turns correctly", () => {
+    const manager = new TurnManager(vi.fn(), vi.fn(), vi.fn(), vi.fn());
 
-    let state = createBaseState('npc1', 1);
+    let state = createBaseState("npc1", 1);
     state = manager.advanceTurn(state);
-    expect(state.currentTurn).toBe('npc2');
+    expect(state.currentTurn).toBe("npc2");
     expect(state.turnCounter).toBe(1);
 
     state = manager.advanceTurn(state);
-    expect(state.currentTurn).toBe('druid');
+    expect(state.currentTurn).toBe("druid");
     expect(state.turnCounter).toBe(1);
 
     state = manager.advanceTurn(state);
-    expect(state.currentTurn).toBe('npc1');
+    expect(state.currentTurn).toBe("npc1");
     expect(state.turnCounter).toBe(2);
   });
 
-  it('manualAdvanceTurn advances when game not ended', () => {
+  it("manualAdvanceTurn advances when game not ended", () => {
     const setGameState = vi.fn();
     const manager = new TurnManager(
       setGameState,
@@ -100,15 +98,17 @@ describe('TurnManager', () => {
     manager.manualAdvanceTurn();
     expect(setGameState).toHaveBeenCalledTimes(1);
 
-    const updateFn = setGameState.mock.calls[0][0] as (s: GameState) => GameState;
-    const base = createBaseState('npc1', 1);
+    const updateFn = setGameState.mock.calls[0][0] as (
+      s: GameState,
+    ) => GameState;
+    const base = createBaseState("npc1", 1);
     const result = updateFn(base);
 
-    expect(result.currentTurn).toBe('npc2');
+    expect(result.currentTurn).toBe("npc2");
     expect(result.turnCounter).toBe(1);
   });
 
-  it('manualAdvanceTurn does not advance when game ended', () => {
+  it("manualAdvanceTurn does not advance when game ended", () => {
     const setGameState = vi.fn();
     const checkEnd = vi.fn().mockReturnValue(true);
     const manager = new TurnManager(setGameState, vi.fn(), vi.fn(), checkEnd);
@@ -116,15 +116,17 @@ describe('TurnManager', () => {
     manager.manualAdvanceTurn();
     expect(setGameState).toHaveBeenCalledTimes(1);
 
-    const updateFn = setGameState.mock.calls[0][0] as (s: GameState) => GameState;
-    const base = createBaseState('npc1', 1);
+    const updateFn = setGameState.mock.calls[0][0] as (
+      s: GameState,
+    ) => GameState;
+    const base = createBaseState("npc1", 1);
     const result = updateFn(base);
 
     expect(checkEnd).toHaveBeenCalledWith(base);
     expect(result).toBe(base);
   });
 
-  it('executeTurn resolves NPC turns using timers', async () => {
+  it("executeTurn resolves NPC turns using timers", async () => {
     vi.useFakeTimers();
 
     const setGameState = vi.fn();
@@ -136,10 +138,10 @@ describe('TurnManager', () => {
       vi.fn().mockReturnValue(false),
     );
 
-    vi.spyOn(manager, 'rollDiceWithAnimation').mockResolvedValue(4);
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+    vi.spyOn(manager, "rollDiceWithAnimation").mockResolvedValue(4);
+    vi.spyOn(Math, "random").mockReturnValue(0);
 
-    const base = createBaseState('npc1', 1);
+    const base = createBaseState("npc1", 1);
     base.npc2.stats.armor = 5;
     base.npc2.stats.maxArmor = 5;
 
@@ -154,7 +156,7 @@ describe('TurnManager', () => {
     )(base);
 
     expect(addLogEntry).toHaveBeenCalledTimes(1);
-    expect(addLogEntry.mock.calls[0][0]).toContain('Gareth attacks');
+    expect(addLogEntry.mock.calls[0][0]).toContain("Gareth attacks");
 
     expect(stateAfterAction.npc2.stats.armor).toBe(0);
     expect(stateAfterAction.npc2.stats.health).toBe(5);
@@ -164,14 +166,14 @@ describe('TurnManager', () => {
       setGameState.mock.calls[1][0] as (s: GameState) => GameState
     )(stateAfterAction);
 
-    expect(finalState.currentTurn).toBe('npc2');
+    expect(finalState.currentTurn).toBe("npc2");
     expect(finalState.turnCounter).toBe(1);
 
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('skips turn when NPC is snared', async () => {
+  it("skips turn when NPC is snared", async () => {
     vi.useFakeTimers();
 
     const setGameState = vi.fn();
@@ -183,7 +185,7 @@ describe('TurnManager', () => {
       vi.fn().mockReturnValue(false),
     );
 
-    const base = createBaseState('npc1', 1);
+    const base = createBaseState("npc1", 1);
     (base as any).npc1.immobilized = 1;
 
     const promise = manager.executeTurn(base);
@@ -191,15 +193,20 @@ describe('TurnManager', () => {
     await promise;
 
     expect(addLogEntry).toHaveBeenCalledWith(
-      expect.stringContaining('restrained'),
+      expect.stringContaining("restrained"),
     );
 
-    expect(setGameState).toHaveBeenCalledTimes(1);
-    const updated = (setGameState.mock.calls[0][0] as (s: GameState) => GameState)(base);
-    expect(updated.currentTurn).toBe('npc2');
-    expect((updated as any).npc1.immobilized).toBe(0);
+    expect(setGameState).toHaveBeenCalledTimes(2);
+    const afterDebuff = (
+      setGameState.mock.calls[0][0] as (s: GameState) => GameState
+    )(base);
+    expect(afterDebuff.npc1.immobilized).toBe(0);
+
+    const updated = (
+      setGameState.mock.calls[1][0] as (s: GameState) => GameState
+    )(afterDebuff);
+    expect(updated.currentTurn).toBe("npc2");
 
     vi.useRealTimers();
   });
 });
-


### PR DESCRIPTION
## Summary
- indicate Vine Snare duration on NPCs
- allow NPC turns to auto-advance when immobilized
- update TurnManager tests

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_684915ef0e988324aa4a9b7c204094d0