### PR TITLE
Adjust map action panel

### DIFF
--- a/client/src/components/game/PlayerActionPanel.tsx
+++ b/client/src/components/game/PlayerActionPanel.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, Maximize2, Minimize2 } from 'lucide-react';
+import { Eye, EyeOff, Maximize2, Minimize2, TreePine, Package, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { PCAbility } from '@/lib/characterLoader';
@@ -10,6 +10,9 @@ interface PlayerActionPanelProps {
   abilities: PCAbility[];
   onAbilityUse: (abilityKey: string) => void;
   onEndTurn: () => void;
+  onOpenInventory?: () => void;
+  onOpenSkills?: () => void;
+  onExitGame?: () => void;
   onToggleCombatLog: () => void;
   combatLogMode: 'hidden' | 'small' | 'large';
   isPlayerTurn: boolean;
@@ -23,6 +26,9 @@ export default function PlayerActionPanel({
   abilities,
   onAbilityUse,
   onEndTurn,
+  onOpenInventory,
+  onOpenSkills,
+  onExitGame,
   onToggleCombatLog,
   combatLogMode,
   isPlayerTurn,
@@ -83,8 +89,35 @@ export default function PlayerActionPanel({
             ))}
           </div>
 
-          {/* Right side - End Turn and Combat Log Controls */}
+          {/* Right side - Utility Buttons */}
           <div className="flex items-center space-x-2">
+            {onOpenSkills && (
+              <Button
+                onClick={onOpenSkills}
+                className="w-14 h-14 p-0 rounded-lg bg-purple-600 hover:bg-purple-700 border-2 border-purple-400 text-white transition-all duration-200"
+                title="Open Skills"
+              >
+                <TreePine className="w-5 h-5" />
+              </Button>
+            )}
+            {onOpenInventory && (
+              <Button
+                onClick={onOpenInventory}
+                className="w-14 h-14 p-0 rounded-lg bg-amber-600 hover:bg-amber-700 border-2 border-amber-400 text-white transition-all duration-200"
+                title="Open Inventory"
+              >
+                <Package className="w-5 h-5" />
+              </Button>
+            )}
+            {onExitGame && (
+              <Button
+                onClick={onExitGame}
+                className="w-14 h-14 p-0 rounded-lg bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white transition-all duration-200"
+                title="Exit Game"
+              >
+                <LogOut className="w-5 h-5" />
+              </Button>
+            )}
             <Button
               onClick={onEndTurn}
               disabled={!isPlayerTurn || targetingMode}

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -1,12 +1,10 @@
 import { useState, useCallback, useEffect } from "react";
-import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
 import { useMapState } from "@/hooks/useMapState";
 import { setGlobalMapState } from "@/lib/mapState";
 import NarrativeScreen from "@/components/narrative/NarrativeScreen";
 import { loadNarrativeScript, type NarrativeScript } from "@/lib/narrativeLoader";
 import { IS_DEBUG } from "@/lib/debug";
-import { LogOut, Package, TreePine } from "lucide-react";
 import ForestZone from "@/components/map/ForestZone";
 import TurnCounter from "@/components/map/TurnCounter";
 import MapDebugPanel from "@/components/map/MapDebugPanel";
@@ -15,7 +13,6 @@ import { globalTimeManager, type TimePhase, getTimeBasedGradient, getTimeBasedEn
 import { globalWeatherManager, useWeatherState } from "@/lib/weatherSystem";
 import { useMapEvents } from "@/hooks/useMapEvents";
 import PlayerActionPanel from "@/components/game/PlayerActionPanel";
-import type { PCAbility } from "@/lib/characterLoader";
 import { globalHistoryManager } from "@/lib/historySystem";
 
 
@@ -31,10 +28,6 @@ export default function Map() {
   const [actionPoints, setActionPoints] = useState(3);
   const maxActionPoints = 3;
   const [combatLogMode, setCombatLogMode] = useState<'hidden' | 'small' | 'large'>('hidden');
-  const placeholderAbilities: PCAbility[] = [
-    { key: 'camp', name: 'Make Camp', description: 'Rest and recover', icon: '⛺', cost: 1 },
-    { key: 'pray', name: 'Pray', description: 'Seek guidance', icon: '🙏', cost: 1 },
-  ];
   const {
     zones,
     currentZone,
@@ -219,7 +212,8 @@ export default function Map() {
 
   const handleEndTurn = useCallback(() => {
     setActionPoints(maxActionPoints);
-  }, []);
+    handleNextTurn();
+  }, [handleNextTurn]);
 
   const handleToggleCombatLog = useCallback(() => {
     setCombatLogMode(prev => prev === 'hidden' ? 'small' : prev === 'small' ? 'large' : 'hidden');
@@ -274,48 +268,18 @@ export default function Map() {
         ))}
       </div>
 
-      {/* Bottom Panel - Right Side */}
-      <div className="absolute bottom-0 right-0 z-30">
-        <div className="p-4">
-          <div className="flex items-center space-x-2">
-            {/* Skills Button */}
-            <Button
-              onClick={handleOpenSkills}
-              className="w-12 h-12 bg-purple-600 hover:bg-purple-700 border-2 border-purple-400 text-white"
-              title="Open Skills"
-            >
-              <TreePine className="w-5 h-5" />
-            </Button>
-
-            {/* Inventory Button */}
-            <Button
-              onClick={handleOpenInventory}
-              className="w-12 h-12 bg-amber-600 hover:bg-amber-700 border-2 border-amber-400 text-white"
-              title="Open Inventory"
-            >
-              <Package className="w-5 h-5" />
-            </Button>
-
-            {/* Exit Game Button */}
-            <Button
-              onClick={handleExitGame}
-              className="w-12 h-12 bg-red-600 hover:bg-red-700 border-2 border-red-400 text-white"
-              title="Exit Game"
-            >
-              <LogOut className="w-5 h-5" />
-            </Button>
-          </div>
-        </div>
-      </div>
 
       {/* Player Action Panel */}
       <PlayerActionPanel
         actionPoints={actionPoints}
         maxActionPoints={maxActionPoints}
         targetingMode={false}
-        abilities={placeholderAbilities}
+        abilities={[]}
         onAbilityUse={handleAbilityUse}
         onEndTurn={handleEndTurn}
+        onOpenInventory={handleOpenInventory}
+        onOpenSkills={handleOpenSkills}
+        onExitGame={handleExitGame}
         onToggleCombatLog={handleToggleCombatLog}
         combatLogMode={combatLogMode}
         isPlayerTurn={true}

--- a/client/src/test/MapEndTurn.test.tsx
+++ b/client/src/test/MapEndTurn.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSetLocation = vi.fn();
+vi.mock('wouter', () => ({
+  useLocation: () => ['', mockSetLocation],
+}));
+
+const nextTurnMock = vi.fn();
+
+vi.mock('../hooks/useMapState', () => ({
+  useMapState: () => ({
+    zones: [],
+    currentZone: '',
+    turnCounter: 1,
+    activeEncounterZone: null,
+    activeWeatherEffect: null,
+    currentTimePhase: 'day1',
+    setCurrentZone: vi.fn(),
+    startEncounter: vi.fn(),
+    resolveEncounter: vi.fn(),
+    nextTurn: nextTurnMock,
+  }),
+}));
+
+const logTurnAdvanceMock = vi.fn();
+vi.mock('../hooks/useMapEvents', () => ({
+  useMapEvents: () => ({
+    addMapEvent: vi.fn(),
+    logTurnAdvance: logTurnAdvanceMock,
+    logEncounterStart: vi.fn(),
+    logEncounterComplete: vi.fn(),
+    logEncounterGenerated: vi.fn(),
+    logZoneChange: vi.fn(),
+    getEventLog: vi.fn(() => []),
+  }),
+}));
+
+vi.mock('../lib/environmentLoader', () => ({
+  loadEnvironmentalEffects: vi.fn().mockResolvedValue({ environmentalEffects: {} }),
+}));
+
+vi.mock('@/lib/timeSystem', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/timeSystem')>('@/lib/timeSystem');
+  return {
+    ...actual,
+    globalTimeManager: {
+      getState: () => ({ currentPhase: 'day1', phaseIndex: 0, turnCounter: 1 }),
+      subscribe: () => () => {},
+      getCurrentPhaseInfo: () => ({
+        name: 'Early Day',
+        icon: '🌅',
+        effectId: 'daylight',
+        colorPalette: { primary: '', secondary: '', accent: '', background: '' },
+      }),
+      getAllPhases: () => ['day1'],
+      setPhase: vi.fn(),
+      getPhaseInfo: () => ({
+        name: 'Early Day',
+        icon: '🌅',
+        effectId: 'daylight',
+        colorPalette: { primary: '', secondary: '', accent: '', background: '' },
+      }),
+    },
+    getTimeBasedGradient: () => '',
+    getTimeBasedEnvironmentalEffect: () => ({ id: 'daylight' }),
+  };
+});
+
+vi.mock('@/lib/weatherSystem', () => ({
+  globalWeatherManager: {
+    loadWeatherData: vi.fn(),
+    getActiveEnvironmentalEffect: vi.fn(() => null),
+    checkForWeatherTrigger: vi.fn(),
+    getWeatherState: vi.fn(() => ({ activeWeather: null })),
+    subscribe: vi.fn(() => () => {}),
+  },
+  useWeatherState: () => null,
+}));
+
+import Map from '../pages/map';
+
+describe('Map end turn', () => {
+  beforeEach(() => {
+    nextTurnMock.mockClear();
+    logTurnAdvanceMock.mockClear();
+    mockSetLocation.mockClear();
+  });
+
+  it('progresses the turn when end turn button clicked', () => {
+    render(<Map />);
+    fireEvent.click(screen.getByTitle('End Turn'));
+    expect(nextTurnMock).toHaveBeenCalled();
+    expect(logTurnAdvanceMock).toHaveBeenCalledWith(2);
+  });
+});

--- a/client/src/test/PlayerActionPanel.test.tsx
+++ b/client/src/test/PlayerActionPanel.test.tsx
@@ -14,6 +14,9 @@ const defaultProps = {
   abilities,
   onAbilityUse: vi.fn(),
   onEndTurn: vi.fn(),
+  onOpenInventory: vi.fn(),
+  onOpenSkills: vi.fn(),
+  onExitGame: vi.fn(),
   onToggleCombatLog: vi.fn(),
   combatLogMode: 'hidden' as const,
   isPlayerTurn: true,
@@ -32,9 +35,15 @@ describe('PlayerActionPanel', () => {
     fireEvent.click(screen.getByTitle(/Make Camp/));
     fireEvent.click(screen.getByTitle('End Turn'));
     fireEvent.click(screen.getByTitle('Combat Log: hidden'));
+    fireEvent.click(screen.getByTitle('Open Inventory'));
+    fireEvent.click(screen.getByTitle('Open Skills'));
+    fireEvent.click(screen.getByTitle('Exit Game'));
     expect(defaultProps.onAbilityUse).toHaveBeenCalledWith('camp');
     expect(defaultProps.onEndTurn).toHaveBeenCalled();
     expect(defaultProps.onToggleCombatLog).toHaveBeenCalled();
+    expect(defaultProps.onOpenInventory).toHaveBeenCalled();
+    expect(defaultProps.onOpenSkills).toHaveBeenCalled();
+    expect(defaultProps.onExitGame).toHaveBeenCalled();
   });
 
   it('disables abilities without points', () => {
@@ -47,5 +56,14 @@ describe('PlayerActionPanel', () => {
     expect(screen.getByText(/Select target/)).toBeInTheDocument();
     fireEvent.click(screen.getByTitle('Cancel pending action'));
     expect(defaultProps.onCancelAction).toHaveBeenCalled();
+  });
+
+  it('hides optional buttons when handlers not provided', () => {
+    render(
+      <PlayerActionPanel {...defaultProps} onOpenInventory={undefined} onOpenSkills={undefined} onExitGame={undefined} />
+    );
+    expect(screen.queryByTitle('Open Inventory')).toBeNull();
+    expect(screen.queryByTitle('Open Skills')).toBeNull();
+    expect(screen.queryByTitle('Exit Game')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- show map controls (skills, inventory, exit game) in `PlayerActionPanel`
- wire end turn button to advance turns
- drop placeholder ability buttons on the map page
- remove unused bottom-right controls
- add tests for new player panel behaviour and end turn logic

## Testing
- `npm run tests`

------
https://chatgpt.com/codex/tasks/task_e_6849172722948324b214ff1172532214